### PR TITLE
Do not build python bindings by default

### DIFF
--- a/tiktoken-rs/Cargo.toml
+++ b/tiktoken-rs/Cargo.toml
@@ -19,5 +19,8 @@ bstr = "1.2.0"
 fancy-regex = "0.11.0"
 lazy_static = "1.4.0"
 parking_lot = "0.12.1"
-pyo3 = "0.18.1"
+pyo3 = { version = "0.18.1", optional = true }
 rustc-hash = "1.1.0"
+
+[features]
+python = ["dep:pyo3"] # build python bindings


### PR DESCRIPTION
Make them crate option instead. This should drop runtime dependency on python and solve problem in https://github.com/zurawiki/tiktoken-rs/issues/5