### PR TITLE
fix: expose num_tokens_from_messages and ensure its implementation is consistent with OpenAI

### DIFF
--- a/tiktoken-rs/tests/tiktoken.rs
+++ b/tiktoken-rs/tests/tiktoken.rs
@@ -14,16 +14,19 @@ fn very_simple_test() {
     assert_eq!(res, vec![b"ab", b"cd"]);
 }
 
+#[test]
 fn test_roundtrip(bpe: &CoreBPE, text: &str) {
     let tokens = bpe.encode_with_special_tokens(text);
     let decoded = bpe.decode(tokens).unwrap();
     assert_eq!(decoded, text);
 }
 
+#[test]
 fn test_decode(bpe: &CoreBPE, text: &str, exected_tokens: Vec<usize>) {
     let tokens = bpe.encode_with_special_tokens(text);
     assert_eq!(tokens, exected_tokens,);
 }
+
 #[test]
 fn p50k_base_test() {
     let bpe = p50k_base().unwrap();

--- a/tiktoken-rs/tests/tiktoken.rs
+++ b/tiktoken-rs/tests/tiktoken.rs
@@ -14,14 +14,12 @@ fn very_simple_test() {
     assert_eq!(res, vec![b"ab", b"cd"]);
 }
 
-#[test]
 fn test_roundtrip(bpe: &CoreBPE, text: &str) {
     let tokens = bpe.encode_with_special_tokens(text);
     let decoded = bpe.decode(tokens).unwrap();
     assert_eq!(decoded, text);
 }
 
-#[test]
 fn test_decode(bpe: &CoreBPE, text: &str, exected_tokens: Vec<usize>) {
     let tokens = bpe.encode_with_special_tokens(text);
     assert_eq!(tokens, exected_tokens,);


### PR DESCRIPTION
Current `num_tokens_from_messages` is not consistent with OpenAI. 

`data.json`:
```json
{
  "model": "gpt-3.5-turbo",
  "max_tokens": 1,
  "messages": [
    {
      "role": "system",
      "content": "You are a helpful, pattern-following assistant that translates corporate jargon into plain English."
    },
    {
      "role": "system",
      "name": "example_user",
      "content": "New synergies will help drive top-line growth."
    },
    {
      "role": "system",
      "name": "example_assistant",
      "content": "Things working well together will increase revenue."
    },
    {
      "role": "system",
      "name": "example_user",
      "content": "Let's circle back when we have more bandwidth to touch base on opportunities for increased leverage."
    },
    {
      "role": "system",
      "name": "example_assistant",
      "content": "Let's talk later when we're less busy about how to do better."
    },
    {
      "role": "user",
      "content": "This late pivot means we don't have time to boil the ocean for the client deliverable."
    }
  ]
}
```

```sh
curl -s -X POST -H "Content-Type: application/json" -d "@data.json" https://api.openai.com/v1/chat/completions -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.usage.prompt_tokens'
```

The result is `127`, but current `num_tokens_from_messages` gives `122`.