### PR TITLE
feat: make async-openai optional 

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ install:
     cargo install --path .
 
 test *args:
-    cargo test
+    cargo test --all-features
 alias t := test
 
 lint:

--- a/tiktoken-rs/Cargo.toml
+++ b/tiktoken-rs/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 anyhow = "1.0.70"
-async-openai = "0.10.0"
+async-openai = { version = "0.10.0", optional = true }
 base64 = "0.21.0"
 bstr = "1.4.0"
 fancy-regex = "0.11.0"
@@ -24,3 +24,4 @@ rustc-hash = "1.1.0"
 
 [features]
 python = ["dep:pyo3"] # build python bindings
+async-openai = ["dep:async-openai"]

--- a/tiktoken-rs/README.md
+++ b/tiktoken-rs/README.md
@@ -66,6 +66,33 @@ let max_tokens = get_chat_completion_max_tokens("gpt-4", &messages).unwrap();
 println!("max_tokens: {}", max_tokens);
 ```
 
+## Counting max_tokens parameter for a chat completion request with [async-openai](https://crates.io/crates/async-openai)
+
+```rust
+use tiktoken_rs::async_openai::get_chat_completion_max_tokens;
+use async_openai::types::{ChatCompletionRequestMessage, Role};
+
+let messages = vec![
+    ChatCompletionRequestMessage {
+        content: "You are a helpful assistant that only speaks French.".to_string(),
+        role: Role::System,
+        name: None,
+    },
+    ChatCompletionRequestMessage {
+        content: "Hello, how are you?".to_string(),
+        role: Role::User,
+        name: None,
+    },
+    ChatCompletionRequestMessage {
+        content: "Parlez-vous francais?".to_string(),
+        role: Role::System,
+        name: None,
+    },
+];
+let max_tokens = get_chat_completion_max_tokens("gpt-4", &messages).unwrap();
+println!("max_tokens: {}", max_tokens);
+```
+
 `tiktoken` supports these encodings used by OpenAI models:
 
 | Encoding name           | OpenAI models                                                             |

--- a/tiktoken-rs/README.md
+++ b/tiktoken-rs/README.md
@@ -68,6 +68,8 @@ println!("max_tokens: {}", max_tokens);
 
 ## Counting max_tokens parameter for a chat completion request with [async-openai](https://crates.io/crates/async-openai)
 
+Need to enable the `async-openai` feature in your `Cargo.toml` file.
+
 ```rust
 use tiktoken_rs::async_openai::get_chat_completion_max_tokens;
 use async_openai::types::{ChatCompletionRequestMessage, Role};

--- a/tiktoken-rs/README.md
+++ b/tiktoken-rs/README.md
@@ -43,7 +43,7 @@ println!("Token count: {}", tokens.len());
 ## Counting max_tokens parameter for a chat completion request
 
 ```rust
-use tiktoken_rs::{get_chat_completion_max_tokens,ChatCompletionRequestMessage};
+use tiktoken_rs::{get_chat_completion_max_tokens, ChatCompletionRequestMessage};
 
 let messages = vec![
     ChatCompletionRequestMessage {

--- a/tiktoken-rs/README.md
+++ b/tiktoken-rs/README.md
@@ -43,20 +43,24 @@ println!("Token count: {}", tokens.len());
 ## Counting max_tokens parameter for a chat completion request
 
 ```rust
-use tiktoken_rs::get_chat_completion_max_tokens;
-use async_openai::types::{ChatCompletionRequestMessageArgs, Role};
+use tiktoken_rs::{get_chat_completion_max_tokens,ChatCompletionRequestMessage};
 
 let messages = vec![
-    ChatCompletionRequestMessageArgs::default()
-        .content("You are a helpful assistant!")
-        .role(Role::System)
-        .build()
-        .unwrap(),
-    ChatCompletionRequestMessageArgs::default()
-        .content("Hello, how are you?")
-        .role(Role::User)
-        .build()
-        .unwrap(),
+    ChatCompletionRequestMessage {
+        content: "You are a helpful assistant that only speaks French.".to_string(),
+        role: "system".to_string(),
+        name: None,
+    },
+    ChatCompletionRequestMessage {
+        content: "Hello, how are you?".to_string(),
+        role: "user".to_string(),
+        name: None,
+    },
+    ChatCompletionRequestMessage {
+        content: "Parlez-vous francais?".to_string(),
+        role: "system".to_string(),
+        name: None,
+    },
 ];
 let max_tokens = get_chat_completion_max_tokens("gpt-4", &messages).unwrap();
 println!("max_tokens: {}", max_tokens);

--- a/tiktoken-rs/src/api.rs
+++ b/tiktoken-rs/src/api.rs
@@ -116,7 +116,7 @@ pub fn num_tokens_from_messages(
 /// # Example
 ///
 /// ```
-/// use tiktoken_rs::{get_chat_completion_max_tokens,ChatCompletionRequestMessage};
+/// use tiktoken_rs::{get_chat_completion_max_tokens, ChatCompletionRequestMessage};
 ///
 /// let model = "gpt-3.5-turbo";
 /// let messages = vec![
@@ -308,11 +308,11 @@ mod tests {
 }
 
 #[cfg(feature = "async-openai")]
-pub mod async_openai_api {
+pub mod async_openai {
     use anyhow::Result;
     use async_openai::types::ChatCompletionRequestMessage;
 
-    pub fn async_openai_num_tokens_from_messages(
+    pub fn num_tokens_from_messages(
         model: &str,
         messages: &[ChatCompletionRequestMessage],
     ) -> Result<usize> {
@@ -327,7 +327,7 @@ pub mod async_openai_api {
         super::num_tokens_from_messages(model, &messages)
     }
 
-    pub fn async_openai_get_chat_completion_max_tokens(
+    pub fn get_chat_completion_max_tokens(
         model: &str,
         messages: &[ChatCompletionRequestMessage],
     ) -> Result<usize> {
@@ -355,8 +355,7 @@ pub mod async_openai_api {
                 name: None,
                 content: "You are a helpful, pattern-following assistant that translates corporate jargon into plain English.".to_string(),
             }];
-            let num_tokens =
-                async_openai_num_tokens_from_messages("gpt-3.5-turbo-0301", messages).unwrap();
+            let num_tokens = num_tokens_from_messages("gpt-3.5-turbo-0301", messages).unwrap();
             assert!(num_tokens > 0);
         }
 
@@ -368,7 +367,7 @@ pub mod async_openai_api {
                 role: Role::System,
                 name: None,
             }];
-            let max_tokens = async_openai_get_chat_completion_max_tokens(model, messages).unwrap();
+            let max_tokens = get_chat_completion_max_tokens(model, messages).unwrap();
             assert!(max_tokens > 0);
         }
     }

--- a/tiktoken-rs/src/api.rs
+++ b/tiktoken-rs/src/api.rs
@@ -310,48 +310,43 @@ mod tests {
 #[cfg(feature = "async-openai")]
 pub mod async_openai {
     use anyhow::Result;
-    use async_openai::types::ChatCompletionRequestMessage;
 
-    pub fn num_tokens_from_messages(
-        model: &str,
-        messages: &[ChatCompletionRequestMessage],
-    ) -> Result<usize> {
-        let messages = messages
-            .iter()
-            .map(|m| super::ChatCompletionRequestMessage {
+    impl From<&async_openai::types::ChatCompletionRequestMessage>
+        for super::ChatCompletionRequestMessage
+    {
+        fn from(m: &async_openai::types::ChatCompletionRequestMessage) -> Self {
+            Self {
                 role: m.role.to_string(),
                 name: m.name.clone(),
                 content: m.content.clone(),
-            })
-            .collect::<Vec<_>>();
+            }
+        }
+    }
+
+    pub fn num_tokens_from_messages(
+        model: &str,
+        messages: &[async_openai::types::ChatCompletionRequestMessage],
+    ) -> Result<usize> {
+        let messages = messages.iter().map(|m| m.into()).collect::<Vec<_>>();
         super::num_tokens_from_messages(model, &messages)
     }
 
     pub fn get_chat_completion_max_tokens(
         model: &str,
-        messages: &[ChatCompletionRequestMessage],
+        messages: &[async_openai::types::ChatCompletionRequestMessage],
     ) -> Result<usize> {
-        let messages = messages
-            .iter()
-            .map(|m| super::ChatCompletionRequestMessage {
-                role: m.role.to_string(),
-                name: m.name.clone(),
-                content: m.content.clone(),
-            })
-            .collect::<Vec<_>>();
+        let messages = messages.iter().map(|m| m.into()).collect::<Vec<_>>();
         super::get_chat_completion_max_tokens(model, &messages)
     }
 
     #[cfg(test)]
     mod tests {
-        use async_openai::types::{ChatCompletionRequestMessage, Role};
-
         use super::*;
 
         #[test]
         fn test_num_tokens_from_messages() {
-            let messages = &[ChatCompletionRequestMessage {
-                role: Role::System,
+            let messages = &[async_openai::types::ChatCompletionRequestMessage {
+                role: async_openai::types::Role::System,
                 name: None,
                 content: "You are a helpful, pattern-following assistant that translates corporate jargon into plain English.".to_string(),
             }];
@@ -362,9 +357,9 @@ pub mod async_openai {
         #[test]
         fn test_get_chat_completion_max_tokens() {
             let model = "gpt-3.5-turbo";
-            let messages = &[ChatCompletionRequestMessage {
+            let messages = &[async_openai::types::ChatCompletionRequestMessage {
                 content: "You are a helpful assistant that only speaks French.".to_string(),
-                role: Role::System,
+                role: async_openai::types::Role::System,
                 name: None,
             }];
             let max_tokens = get_chat_completion_max_tokens(model, messages).unwrap();

--- a/tiktoken-rs/src/api.rs
+++ b/tiktoken-rs/src/api.rs
@@ -1,4 +1,5 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
+#[cfg(feature = "async-openai")]
 use async_openai::types::ChatCompletionRequestMessage;
 
 use crate::{
@@ -49,6 +50,7 @@ pub fn get_completion_max_tokens(model: &str, prompt: &str) -> Result<usize> {
 
 /// Calculates the number of tokens for chat completion based on the model and messages provided.
 /// Based on https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
+#[cfg(feature = "async-openai")]
 pub fn num_tokens_from_messages(
     model: &str,
     messages: &[ChatCompletionRequestMessage],
@@ -56,7 +58,7 @@ pub fn num_tokens_from_messages(
     let tokenizer =
         get_tokenizer(model).ok_or_else(|| anyhow!("No tokenizer found for model {}", model))?;
     if tokenizer != Tokenizer::Cl100kBase {
-        bail!("Chat completion is only supported chat models")
+        anyhow::bail!("Chat completion is only supported chat models")
     }
     let bpe = get_bpe_from_tokenizer(tokenizer)?;
 
@@ -163,6 +165,7 @@ pub fn num_tokens_from_messages(
 ///
 /// If successful, the function returns a `Result` containing the maximum number of tokens available for chat completion,
 /// based on the given model and messages.
+#[cfg(feature = "async-openai")]
 pub fn get_chat_completion_max_tokens(
     model: &str,
     messages: &[ChatCompletionRequestMessage],
@@ -245,7 +248,8 @@ pub fn get_bpe_from_tokenizer(tokenizer: Tokenizer) -> Result<CoreBPE> {
 
 #[cfg(test)]
 mod tests {
-    use async_openai::types::Role;
+    #[cfg(feature = "async-openai")]
+    use async_openai::types::{ChatCompletionRequestMessage, Role};
 
     use super::*;
 
@@ -256,6 +260,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "async-openai")]
     fn test_num_tokens_from_messages() {
         let messages = vec![
             ChatCompletionRequestMessage {
@@ -297,6 +302,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "async-openai")]
     fn test_get_chat_completion_max_tokens() {
         let model = "gpt-3.5-turbo";
         let messages = vec![

--- a/tiktoken-rs/src/lib.rs
+++ b/tiktoken-rs/src/lib.rs
@@ -4,8 +4,6 @@ mod singleton;
 mod tiktoken_ext;
 mod vendor_tiktoken;
 
-#[cfg(feature = "async-openai")]
-pub use api::async_openai_api::*;
 pub use api::*;
 pub mod model;
 pub mod tokenizer;

--- a/tiktoken-rs/src/lib.rs
+++ b/tiktoken-rs/src/lib.rs
@@ -4,6 +4,8 @@ mod singleton;
 mod tiktoken_ext;
 mod vendor_tiktoken;
 
+#[cfg(feature = "async-openai")]
+pub use api::async_openai_api::*;
 pub use api::*;
 pub mod model;
 pub mod tokenizer;


### PR DESCRIPTION
## What changed

Make `async-openai` and related `get_chat_completion_max_tokens`, `num_tokens_from_messages` optional.

## Reason

I made a [Go binding](https://github.com/j178/tiktoken-go) for tiktoken-rs, `async-openai` is not necessary but it introduced a lot dependencies, resulting in a larger static library. Ideally, it should be an optional feature.

Relates to #10 