### PR TITLE
Add ability to tokenize a string and return the decoded tokens using the correct BPE model

### DIFF
--- a/tiktoken-rs/src/api.rs
+++ b/tiktoken-rs/src/api.rs
@@ -46,7 +46,7 @@ pub fn get_completion_max_tokens(model: &str, prompt: &str) -> Result<usize> {
     Ok(context_size.saturating_sub(prompt_tokens))
 }
 
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ChatCompletionRequestMessage {
     /// The role of the author of this message.
     pub role: String,

--- a/tiktoken-rs/tests/tiktoken.rs
+++ b/tiktoken-rs/tests/tiktoken.rs
@@ -85,9 +85,10 @@ fn cl100k_base_test() {
 #[test]
 fn cl100k_split_test() {
     let bpe = cl100k_base().unwrap();
-    let tokenized = bpe
+    let tokenized: Result<Vec<_>, _> = bpe
         .split_by_token_with_special_tokens("This is a test         with a lot of spaces")
-        .unwrap();
+        .collect();
+    let tokenized = tokenized.unwrap();
     assert_eq!(
         tokenized,
         vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]

--- a/tiktoken-rs/tests/tiktoken.rs
+++ b/tiktoken-rs/tests/tiktoken.rs
@@ -83,6 +83,13 @@ fn cl100k_base_test() {
 }
 
 #[test]
+fn cl100k_split_test() {
+    let bpe = cl100k_base().unwrap();
+    let tokenized = bpe.split_by_token_with_special_tokens("This is a test         with a lot of spaces").unwrap();
+    assert_eq!(tokenized, vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]);
+}
+
+#[test]
 fn p50k_base_singleton_test() {
     // let now = std::time::Instant::now();
     let bpe1 = p50k_base_singleton();

--- a/tiktoken-rs/tests/tiktoken.rs
+++ b/tiktoken-rs/tests/tiktoken.rs
@@ -85,8 +85,13 @@ fn cl100k_base_test() {
 #[test]
 fn cl100k_split_test() {
     let bpe = cl100k_base().unwrap();
-    let tokenized = bpe.split_by_token_with_special_tokens("This is a test         with a lot of spaces").unwrap();
-    assert_eq!(tokenized, vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]);
+    let tokenized = bpe
+        .split_by_token_with_special_tokens("This is a test         with a lot of spaces")
+        .unwrap();
+    assert_eq!(
+        tokenized,
+        vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This pull request adds the ability to tokenize a string and return the decoded tokens using the correct Byte Pair Encoding (BPE) model in the Rust tokenizer "tiktoken". The current functionality of tiktoken only allows encoding a string into a vector of references to the token table or decoding it back into the original string.

Changes include:

1. A new function `_decode_native_and_split` that decodes encoded BPE tokens into their corresponding byte arrays and returns a vector of vectors of bytes.
2. A new function `split_by_token_with_special_tokens` that takes in a string, encodes it using the BPE model, and then decodes the encoded tokens into a vector of strings. This allows for tokenizing a string and returning the decoded tokens using the correct BPE model.
3. A new test `cl100k_split_test` has been added to tests/tiktoken.rs to ensure the correct behavior of the new functions.

Example usage:

```
let bpe = cl100k_base().unwrap();
let tokenized = bpe.split_by_token_with_special_tokens("This is a test         with a lot of spaces").unwrap();
assert_eq!(tokenized, vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]);
```

With these changes, users can now utilize the tiktoken library to tokenize and decode text using the correct BPE model, enhancing its functionality and usability.

 Closes #16