### PR TITLE
Improved interface for split_by_token

### DIFF
--- a/tiktoken-rs/tests/tiktoken.rs
+++ b/tiktoken-rs/tests/tiktoken.rs
@@ -86,7 +86,7 @@ fn cl100k_base_test() {
 fn cl100k_split_test() {
     let bpe = cl100k_base().unwrap();
     let tokenized: Result<Vec<_>, _> = bpe
-        .split_by_token_with_special_tokens("This is a test         with a lot of spaces")
+        .split_by_token_iter("This is a test         with a lot of spaces", true)
         .collect();
     let tokenized = tokenized.unwrap();
     assert_eq!(


### PR DESCRIPTION
The `split_by_token_ordinary` method and its corresponding iterator `split_by_token_ordinary_iter` have been added to the `CoreBPE` struct in `vendor_tiktoken.rs`. These methods allow for ordinary tokenization of a string without special tokens from the BPE model.

Simplified the .split_by_token_with_special_tokens method to just be `split_by_token` and differentiated between methods that return iter vs collection.