### PR TITLE
Derive Debug for CoreBPE struct

### DIFF
--- a/tiktoken-rs/src/vendor_tiktoken.rs
+++ b/tiktoken-rs/src/vendor_tiktoken.rs
@@ -199,7 +199,7 @@ pub struct CoreBPE {
 }
 
 #[cfg(not(feature = "python"))]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)] // sorted_token_bytes is used but is read only in python version
 pub struct CoreBPE {
     encoder: HashMap<Vec<u8>, usize>,


### PR DESCRIPTION
Want to be able to include the `CoreBPE` struct within another struct and derive `Debug`.