### PR TITLE
lint: Fix unnecessary raw string

### DIFF
--- a/tiktoken-rs/benches/locking.rs
+++ b/tiktoken-rs/benches/locking.rs
@@ -2,7 +2,7 @@
 extern crate test;
 
 use tiktoken_rs::{cl100k_base, cl100k_base_singleton};
-static CONTENT: &str = r#"Hello world"#;
+static CONTENT: &str = "Hello world";
 
 #[bench]
 fn bench_cl100k_singleton_roundtrip(b: &mut test::Bencher) {


### PR DESCRIPTION
Should fix lint failure:

https://github.com/zurawiki/tiktoken-rs/actions/runs/6348056885/job/17243994544
```
error: unnecessary hashes around raw string literal
 --> tiktoken-rs/benches/locking.rs:5:24
  |
5 | static CONTENT: &str = r#"Hello world"#;
  |                        ^^^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_raw_string_hashes
  = note: `-D clippy::needless-raw-string-hashes` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::needless_raw_string_hashes)]`
help: remove all the hashes around the literal
  |
5 - static CONTENT: &str = r#"Hello world"#;
5 + static CONTENT: &str = r"Hello world";
  |

error: could not compile `tiktoken-rs` (bench "locking") due to previous error
warning: build failed, waiting for other jobs to finish...
error: Recipe `lint` failed on line 33 with exit code 101
```