### PR TITLE
return correct context length for `text-embedding-ada-002`

### DIFF
--- a/tiktoken-rs/src/model.rs
+++ b/tiktoken-rs/src/model.rs
@@ -62,5 +62,8 @@ pub fn get_context_size(model: &str) -> usize {
     if starts_with_any!(model, "text-ada-001", "text-babbage-001", "text-curie-001") {
         return 2049;
     }
+    if starts_with_any!(model, "text-embedding-ada-002") {
+        return 8192;
+    }
     4096
 }


### PR DESCRIPTION
from https://openai.com/blog/new-and-improved-embedding-model:
```
Longer context. The context length of the new model is increased by a factor of four, from 2048 to 8192, making it more convenient to work with long documents.
```