### PR TITLE
Add tokenizer prefixes for fine-tuned models

### DIFF
--- a/tiktoken-rs/src/tokenizer.rs
+++ b/tiktoken-rs/src/tokenizer.rs
@@ -31,6 +31,12 @@ const MODEL_PREFIX_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
     // chat
     ("gpt-4-", Tokenizer::Cl100kBase),
     ("gpt-3.5-turbo-", Tokenizer::Cl100kBase),
+    ("gpt-35-turbo-", Tokenizer::Cl100kBase),
+    // fine-tuned
+    ("ft:gpt-4", Tokenizer::Cl100kBase),
+    ("ft:gpt-3.5-turbo", Tokenizer::Cl100kBase),
+    ("ft:davinci-002", Tokenizer::Cl100kBase),
+    ("ft:babbage-002", Tokenizer::Cl100kBase),
 ];
 
 const MODEL_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
@@ -136,6 +142,10 @@ mod tests {
             Some(Tokenizer::Cl100kBase)
         );
         assert_eq!(get_tokenizer("gpt-3.5-turbo"), Some(Tokenizer::Cl100kBase));
+        assert_eq!(
+            get_tokenizer("ft:gpt-3.5-turbo:XXXXXX:2023-11-11"),
+            Some(Tokenizer::Cl100kBase)
+        );
         assert_eq!(
             get_tokenizer("gpt-3.5-turbo-0301"),
             Some(Tokenizer::Cl100kBase)


### PR DESCRIPTION
The python `tiktoken` API supports prefixes for fine-tuned models (_e.g._ [here](https://github.com/openai/tiktoken/blob/9e79899bc248d5313c7dd73562b5e211d728723d/tiktoken/model.py#L11)), whereas `tiktoken-rs` doesn't.
It means that methods that require a tokenizer instance from a fine-tuned model name will all fail.
This PR simply proposes to support existing fine-tuned model names.
Simple unit test is provided as well.