### PR TITLE
Add `gpt-4-0125` and `gpt-3.5-turbo-1106` context sizes

### DIFF
--- a/tiktoken-rs/src/model.rs
+++ b/tiktoken-rs/src/model.rs
@@ -32,7 +32,7 @@ macro_rules! starts_with_any {
 ///
 /// This function does not panic. It returns a default value of 4096 if the model is not recognized.
 pub fn get_context_size(model: &str) -> usize {
-    if_starts_with_any!(model, "gpt-4-0125"){
+    if starts_with_any!(model, "gpt-4-0125") {
         return 128_000;
     }
     if starts_with_any!(model, "gpt-4-1106") {
@@ -44,7 +44,7 @@ pub fn get_context_size(model: &str) -> usize {
     if starts_with_any!(model, "gpt-4") {
         return 8192;
     }
-    if starts_with_any!(model, "gpt-3.5-turbo-1106"){
+    if starts_with_any!(model, "gpt-3.5-turbo-1106") {
         return 16_385;
     }
     if starts_with_any!(model, "gpt-3.5-turbo-16k") {

--- a/tiktoken-rs/src/model.rs
+++ b/tiktoken-rs/src/model.rs
@@ -32,6 +32,9 @@ macro_rules! starts_with_any {
 ///
 /// This function does not panic. It returns a default value of 4096 if the model is not recognized.
 pub fn get_context_size(model: &str) -> usize {
+    if_starts_with_any!(model, "gpt-4-0125"){
+        return 128_000;
+    }
     if starts_with_any!(model, "gpt-4-1106") {
         return 128_000;
     }
@@ -40,6 +43,9 @@ pub fn get_context_size(model: &str) -> usize {
     }
     if starts_with_any!(model, "gpt-4") {
         return 8192;
+    }
+    if starts_with_any!(model, "gpt-3.5-turbo-1106"){
+        return 16_385;
     }
     if starts_with_any!(model, "gpt-3.5-turbo-16k") {
         return 16_384;

--- a/tiktoken-rs/src/tokenizer.rs
+++ b/tiktoken-rs/src/tokenizer.rs
@@ -136,7 +136,10 @@ mod tests {
 
     #[test]
     fn test_get_tokenizer() {
-        assert_eq!(get_tokenizer("gpt-4-0125-preview"), Some(Tokenizer::Cl100kBase));
+        assert_eq!(
+            get_tokenizer("gpt-4-0125-preview"),
+            Some(Tokenizer::Cl100kBase)
+        );
         assert_eq!(get_tokenizer("gpt-4-32k-0314"), Some(Tokenizer::Cl100kBase));
         assert_eq!(
             get_tokenizer("gpt-4-1106-preview"),

--- a/tiktoken-rs/src/tokenizer.rs
+++ b/tiktoken-rs/src/tokenizer.rs
@@ -142,6 +142,10 @@ mod tests {
             get_tokenizer("gpt-4-1106-preview"),
             Some(Tokenizer::Cl100kBase)
         );
+        assert_eq!(
+            get_tokenizer("gpt-3.5-turbo-1106"),
+            Some(Tokenizer::Cl100kBase),
+        );
         assert_eq!(get_tokenizer("gpt-3.5-turbo"), Some(Tokenizer::Cl100kBase));
         assert_eq!(
             get_tokenizer("ft:gpt-3.5-turbo:XXXXXX:2023-11-11"),

--- a/tiktoken-rs/src/tokenizer.rs
+++ b/tiktoken-rs/src/tokenizer.rs
@@ -136,6 +136,7 @@ mod tests {
 
     #[test]
     fn test_get_tokenizer() {
+        assert_eq!(get_tokenizer("gpt-4-0125"), Some(Tokenizer::Cl100kBase));
         assert_eq!(get_tokenizer("gpt-4-32k-0314"), Some(Tokenizer::Cl100kBase));
         assert_eq!(
             get_tokenizer("gpt-4-1106-preview"),

--- a/tiktoken-rs/src/tokenizer.rs
+++ b/tiktoken-rs/src/tokenizer.rs
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn test_get_tokenizer() {
-        assert_eq!(get_tokenizer("gpt-4-0125"), Some(Tokenizer::Cl100kBase));
+        assert_eq!(get_tokenizer("gpt-4-0125-preview"), Some(Tokenizer::Cl100kBase));
         assert_eq!(get_tokenizer("gpt-4-32k-0314"), Some(Tokenizer::Cl100kBase));
         assert_eq!(
             get_tokenizer("gpt-4-1106-preview"),


### PR DESCRIPTION
There are a few new models released today from OpenAI

Links:

- https://openai.com/blog/new-embedding-models-and-api-updates
- https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo

So, I added `gpt-4-0125-preview` and `gpt-3.5-turbo-1106` context sizes to the repo, so the library can report their context size correctly.

Can you check if these changes make sense? Thanks!