### PR TITLE
Fix context size for fine-tuned models

### DIFF
--- a/tiktoken-rs/src/model.rs
+++ b/tiktoken-rs/src/model.rs
@@ -32,6 +32,10 @@ macro_rules! starts_with_any {
 ///
 /// This function does not panic. It returns a default value of 4096 if the model is not recognized.
 pub fn get_context_size(model: &str) -> usize {
+    if let Some(rest) = model.strip_prefix("ft:") {
+        let base = rest.split(':').next().unwrap_or(rest);
+        return get_context_size(base);
+    }
     if starts_with_any!(model, "o1-") {
         return 128_000;
     }

--- a/tiktoken-rs/tests/model.rs
+++ b/tiktoken-rs/tests/model.rs
@@ -1,0 +1,13 @@
+use tiktoken_rs::model::get_context_size;
+
+#[test]
+fn test_finetuned_context_size() {
+    assert_eq!(
+        get_context_size("ft:gpt-3.5-turbo-0125:custom"),
+        get_context_size("gpt-3.5-turbo-0125")
+    );
+    assert_eq!(
+        get_context_size("ft:gpt-4o:custom"),
+        get_context_size("gpt-4o")
+    );
+}


### PR DESCRIPTION
## Summary
- respect fine-tuned model prefixes when computing context size
- add regression test for fine-tuned model names

## Testing
- `cargo test --locked --offline` *(fails: no matching package named `anyhow` found)*