### PR TITLE
Add tiktoken CLI 🚀

### DIFF
--- a/tiktoken-rs/Cargo.toml
+++ b/tiktoken-rs/Cargo.toml
@@ -13,6 +13,10 @@ documentation = "https://docs.rs/crate/tiktoken-rs/"
 license = "MIT"
 readme = "../README.md"
 
+[[bin]]
+name = "tiktoken"
+path = "src/main.rs"
+
 [profile.release]
 debug = 1
 
@@ -21,11 +25,14 @@ anyhow = "1.0.76"
 async-openai = { version = "0.14.2", optional = true }
 base64 = "0.22.0"
 bstr = "1.6.2"
+clap = { version = "4.4", features = ["derive"] }
 dhat = { version = "0.3.2", optional = true }
 fancy-regex = "0.13.0"
 lazy_static = "1.4.0"
 regex = "1.10.3"
 rustc-hash = "1.1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [features]
 async-openai = ["dep:async-openai"]

--- a/tiktoken-rs/README.md
+++ b/tiktoken-rs/README.md
@@ -18,6 +18,35 @@ This library is built on top of the `tiktoken` library and includes some additio
 
 For full working examples for all supported features, see the [examples](https://github.com/zurawiki/tiktoken-rs/tree/main/tiktoken-rs/examples) directory in the repository.
 
+# CLI Usage
+
+The project includes a command-line interface for token counting:
+
+```bash
+# Count tokens in text from stdin
+echo "Hello, world!" | cargo run --bin tiktoken
+
+# Count tokens with a specific model
+echo "Hello, world!" | cargo run --bin tiktoken -- --model gpt-3.5-turbo
+
+# Count tokens with the o1 model
+echo "Hello, world!" | cargo run --bin tiktoken -- --model o1
+
+# Get help
+cargo run --bin tiktoken -- --help
+```
+
+The CLI outputs JSON with token count, model used, context size, and remaining tokens:
+
+```json
+{
+  "token_count": 4,
+  "model": "gpt-4",
+  "context_size": 8192,
+  "remaining_tokens": 8188
+}
+```
+
 # Usage
 
 1. Install this tool locally with `cargo`

--- a/tiktoken-rs/README.md
+++ b/tiktoken-rs/README.md
@@ -20,20 +20,34 @@ For full working examples for all supported features, see the [examples](https:/
 
 # CLI Usage
 
-The project includes a command-line interface for token counting:
+The project includes a command-line interface for token counting.
+
+## Installation
+
+```shell
+cargo install tiktoken-rs
+```
+
+## Usage
 
 ```bash
+# Get help
+tiktoken --help
+
+# List all available models
+tiktoken --list-models
+
 # Count tokens in text from stdin
-echo "Hello, world!" | cargo run --bin tiktoken
+echo 'Hello, world!' | tiktoken
 
 # Count tokens with a specific model
-echo "Hello, world!" | cargo run --bin tiktoken -- --model gpt-3.5-turbo
+echo 'Hello, world!' | tiktoken --model gpt-3.5-turbo
 
 # Count tokens with the o1 model
-echo "Hello, world!" | cargo run --bin tiktoken -- --model o1
+echo 'Hello, world!' | tiktoken --model o1
 
-# Get help
-cargo run --bin tiktoken -- --help
+# Output JSON with usage percentage
+echo 'Hello, world!' | tiktoken --json
 ```
 
 The CLI outputs JSON with token count, model used, context size, and remaining tokens:

--- a/tiktoken-rs/src/main.rs
+++ b/tiktoken-rs/src/main.rs
@@ -1,0 +1,81 @@
+use clap::Parser;
+use serde::Serialize;
+use std::io::{self, Read};
+use tiktoken_rs::{get_bpe_from_model, model::get_context_size};
+
+#[derive(Parser)]
+#[command(
+    name = "tiktoken",
+    about = "Count tokens in text using OpenAI's tiktoken library",
+    version
+)]
+struct Args {
+    /// Model to use for tokenization (e.g., gpt-4o, gpt-3.5-turbo, o1)
+    #[arg(short, long, default_value = "gpt-4.1")]
+    model: String,
+
+    /// Output format for the results
+    #[arg(short, long, default_value = "count")]
+    output: OutputFormat,
+
+    /// Input text to count tokens for (reads from stdin if not provided)
+    #[arg(value_name = "TEXT")]
+    text: Option<String>,
+}
+
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum OutputFormat {
+    /// Output just the token count (default)
+    Count,
+    /// Output detailed information in JSON format
+    Json,
+}
+
+#[derive(Serialize)]
+struct TokenCountResponse {
+    /// Number of tokens in the input text
+    token_count: usize,
+    /// Model used for tokenization
+    model: String,
+    /// Context size for the model
+    context_size: usize,
+    /// Remaining tokens available for completion
+    remaining_tokens: usize,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    // Get input text from argument or stdin
+    let input_text = if let Some(text) = args.text {
+        text
+    } else {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+        buffer
+    };
+
+    // Count tokens using the specified model
+    let bpe = get_bpe_from_model(&args.model)?;
+    let token_count = bpe.encode_with_special_tokens(&input_text).len();
+    let context_size = get_context_size(&args.model);
+    let remaining_tokens = context_size.saturating_sub(token_count);
+
+    // Output based on the specified format
+    match args.output {
+        OutputFormat::Count => {
+            println!("{}", token_count);
+        }
+        OutputFormat::Json => {
+            let response = TokenCountResponse {
+                token_count,
+                model: args.model,
+                context_size,
+                remaining_tokens,
+            };
+            println!("{}", serde_json::to_string_pretty(&response)?);
+        }
+    }
+
+    Ok(())
+}

--- a/tiktoken-rs/src/main.rs
+++ b/tiktoken-rs/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde::Serialize;
 use std::io::{self, Read};
-use tiktoken_rs::{get_bpe_from_model, model::get_context_size};
+use tiktoken_rs::{get_bpe_from_model, model::get_context_size, tokenizer::list_available_models};
 
 #[derive(Parser)]
 #[command(
@@ -17,6 +17,10 @@ struct Args {
     /// Output format for the results
     #[arg(short, long, default_value = "count")]
     output: OutputFormat,
+
+    /// List all available models and exit
+    #[arg(long)]
+    list_models: bool,
 
     /// Input text to count tokens for (reads from stdin if not provided)
     #[arg(value_name = "TEXT")]
@@ -41,10 +45,33 @@ struct TokenCountResponse {
     context_size: usize,
     /// Remaining tokens available for completion
     remaining_tokens: usize,
+    /// Percentage of context used (rounded to 3 decimal places)
+    usage_percentage: f64,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
+
+    // Handle list models command
+    if args.list_models {
+        println!("Available models:");
+        println!();
+
+        // Get all models from the tokenizer module
+        let models = list_available_models();
+
+        for model in models.iter() {
+            let context_size = get_context_size(model);
+            println!("  {:<25} (context: {})", model, context_size);
+        }
+
+        println!();
+        println!(
+            "Note: Many models support version suffixes (e.g., gpt-4-0314, gpt-3.5-turbo-0125)"
+        );
+        println!("      and fine-tuned models use the ft: prefix (e.g., ft:gpt-3.5-turbo:xxx:2023-11-11)");
+        return Ok(());
+    }
 
     // Get input text from argument or stdin
     let input_text = if !args.text.is_empty() {
@@ -62,6 +89,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let context_size = get_context_size(&args.model);
     let remaining_tokens = context_size.saturating_sub(token_count);
 
+    // Calculate usage percentage rounded to 3 decimal places
+    let usage_percentage = if context_size > 0 {
+        ((token_count as f64 / context_size as f64) * 100.0 * 1000.0).round() / 1000.0
+    } else {
+        0.0
+    };
+
     // Output based on the specified format
     match args.output {
         OutputFormat::Count => {
@@ -73,6 +107,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 model: args.model,
                 context_size,
                 remaining_tokens,
+                usage_percentage,
             };
             println!("{}", serde_json::to_string_pretty(&response)?);
         }

--- a/tiktoken-rs/src/main.rs
+++ b/tiktoken-rs/src/main.rs
@@ -20,7 +20,7 @@ struct Args {
 
     /// Input text to count tokens for (reads from stdin if not provided)
     #[arg(value_name = "TEXT")]
-    text: Option<String>,
+    text: Vec<String>,
 }
 
 #[derive(Clone, Copy, clap::ValueEnum)]
@@ -47,10 +47,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
 
     // Get input text from argument or stdin
-    let input_text = if let Some(text) = args.text {
-        text
+    let input_text = if !args.text.is_empty() {
+        args.text.join(" ")
     } else {
         let mut buffer = String::new();
+        eprintln!("🔎 Reading from stdin...");
         io::stdin().read_to_string(&mut buffer)?;
         buffer
     };

--- a/tiktoken-rs/src/main.rs
+++ b/tiktoken-rs/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Output based on the specified format
     match args.output {
         OutputFormat::Count => {
-            println!("{}", token_count);
+            println!("{token_count}");
         }
         OutputFormat::Json => {
             let response = TokenCountResponse {

--- a/tiktoken-rs/src/main.rs
+++ b/tiktoken-rs/src/main.rs
@@ -14,9 +14,9 @@ struct Args {
     #[arg(short, long, default_value = "gpt-4.1")]
     model: String,
 
-    /// Output format for the results
-    #[arg(short, long, default_value = "count")]
-    output: OutputFormat,
+    /// Output results in JSON format
+    #[arg(long)]
+    json: bool,
 
     /// List all available models and exit
     #[arg(long)]
@@ -25,14 +25,6 @@ struct Args {
     /// Input text to count tokens for (reads from stdin if not provided)
     #[arg(value_name = "TEXT")]
     text: Vec<String>,
-}
-
-#[derive(Clone, Copy, clap::ValueEnum)]
-enum OutputFormat {
-    /// Output just the token count (default)
-    Count,
-    /// Output detailed information in JSON format
-    Json,
 }
 
 #[derive(Serialize)]
@@ -96,21 +88,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         0.0
     };
 
-    // Output based on the specified format
-    match args.output {
-        OutputFormat::Count => {
-            println!("{token_count}");
-        }
-        OutputFormat::Json => {
-            let response = TokenCountResponse {
-                token_count,
-                model: args.model,
-                context_size,
-                remaining_tokens,
-                usage_percentage,
-            };
-            println!("{}", serde_json::to_string_pretty(&response)?);
-        }
+    // Output based on the json flag
+    if args.json {
+        let response = TokenCountResponse {
+            token_count,
+            model: args.model,
+            context_size,
+            remaining_tokens,
+            usage_percentage,
+        };
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("{token_count}");
     }
 
     Ok(())

--- a/tiktoken-rs/src/tokenizer.rs
+++ b/tiktoken-rs/src/tokenizer.rs
@@ -51,7 +51,7 @@ const MODEL_PREFIX_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
 
 // Keep this in sync with:
 // https://github.com/openai/tiktoken/blob/63527649963def8c759b0f91f2eb69a40934e468/tiktoken/model.py#L22
-const MODEL_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
+pub const MODEL_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
     // reasoning
     ("o1", Tokenizer::O200kBase),
     ("o3", Tokenizer::O200kBase),
@@ -117,6 +117,27 @@ lazy_static! {
         });
         map
     };
+}
+
+/// Returns a list of all available model names.
+///
+/// This function returns all the model names that are supported by the tokenizer.
+/// The models are returned in the order they are defined in the `MODEL_TO_TOKENIZER` constant.
+///
+/// # Examples
+///
+/// ```
+/// use tiktoken_rs::tokenizer::list_available_models;
+/// let models = list_available_models();
+/// assert!(models.contains(&"gpt-4"));
+/// assert!(models.contains(&"gpt-3.5-turbo"));
+/// ```
+///
+/// # Returns
+///
+/// A vector of string slices containing all available model names.
+pub fn list_available_models() -> Vec<&'static str> {
+    MODEL_TO_TOKENIZER.iter().map(|(model, _)| *model).collect()
 }
 
 /// Returns the tokenizer type used by a model.


### PR DESCRIPTION
## Add `tiktoken` CLI tool for quick token counting 🚀

### Motivation
While building LLM-powered tools/agents, I'm finding the need to quickly count tokens in prompt files and potential input data to estimate context usage (token cost 💰).

### Changes
- Added CLI binary target with `clap`-based argument parsing
- Updated README with usage examples

### Usage
```bash
# Count tokens and show JSON output format
$ bat README.md | tiktoken --json
🔎 Reading from stdin... # shown on stderr
{
  "token_count": 1478,
  "model": "gpt-4.1",
  "context_size": 1047576,
  "remaining_tokens": 1046098,
  "usage_percentage": 0.141
}

# Specific model
tiktoken --model gpt-4o "Your text here"

# List available models
tiktoken --list-models
```

### Installation
```bash
cargo install tiktoken-rs
```

The CLI tool will be available as `tiktoken` after installation.