### PR TITLE
bump fancy-regex to 0.16

### DIFF
--- a/tiktoken-rs/Cargo.toml
+++ b/tiktoken-rs/Cargo.toml
@@ -22,7 +22,7 @@ async-openai = { version = "0.14.2", optional = true }
 base64 = "0.22.0"
 bstr = "1.6.2"
 dhat = { version = "0.3.2", optional = true }
-fancy-regex = "0.13.0"
+fancy-regex = "0.16"
 lazy_static = "1.4.0"
 regex = "1.10.3"
 rustc-hash = "1.1.0"


### PR DESCRIPTION
A panic can be triggered with a pretty basic input:
```
let bpe = o200k_base().unwrap();
let tokens = bpe.encode_with_special_tokens(&"A".repeat(1_000_000));
```

```
thread 'main' panicked at tiktoken-rs/src/vendor_tiktoken.rs:267:33:
called `Result::unwrap()` on an `Err` value: RuntimeError(StackOverflow)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

There's a fix in [fancy-regex 0.16](https://github.com/fancy-regex/fancy-regex/pull/171) that reduces stackoverflow errors for large inputs. (it doesn't really complete, but it also doesn't panic).