### PR TITLE
Return Option from get_context_size, improve error messages, bump to 0.11.0

### DIFF
--- a/tiktoken-rs/Cargo.toml
+++ b/tiktoken-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiktoken-rs"
-version = "0.10.0"
+version = "0.11.0"
 description = "Library for encoding and decoding with the tiktoken library in Rust"
 include = ["assets/**/*", "src/**/*", "README.md"]
 edition = "2021"

--- a/tiktoken-rs/src/api.rs
+++ b/tiktoken-rs/src/api.rs
@@ -33,7 +33,8 @@ use crate::{
 /// let max_tokens = get_text_completion_max_tokens("gpt-4o", "Translate to French: '").unwrap();
 /// ```
 pub fn get_text_completion_max_tokens(model: &str, prompt: &str) -> Result<usize> {
-    let context_size = get_context_size(model);
+    let context_size = get_context_size(model)
+        .ok_or_else(|| anyhow!("Unknown context size for model {}", model))?;
     let tokenizer =
         get_tokenizer(model).ok_or_else(|| anyhow!("No tokenizer found for model {}", model))?;
     let bpe = bpe_singleton(tokenizer);
@@ -109,7 +110,12 @@ pub fn num_tokens_from_messages(
         && tokenizer != Tokenizer::O200kBase
         && tokenizer != Tokenizer::O200kHarmony
     {
-        anyhow::bail!("Chat completion is only supported chat models")
+        anyhow::bail!(
+            "Chat token counting is not supported for model {:?} (tokenizer {:?}). \
+             Supported tokenizers: Cl100kBase, O200kBase, O200kHarmony.",
+            model,
+            tokenizer
+        )
     }
     let bpe = bpe_singleton(tokenizer);
 
@@ -215,7 +221,8 @@ pub fn get_chat_completion_max_tokens(
     model: &str,
     messages: &[ChatCompletionRequestMessage],
 ) -> Result<usize> {
-    let context_size = get_context_size(model);
+    let context_size = get_context_size(model)
+        .ok_or_else(|| anyhow!("Unknown context size for model {}", model))?;
     let prompt_tokens = num_tokens_from_messages(model, messages)?;
     Ok(context_size.saturating_sub(prompt_tokens))
 }
@@ -731,6 +738,11 @@ pub mod async_openai {
     }
 
     /// Calculates the total number of tokens for the given list of messages.
+    ///
+    /// **Note:** Only text content is counted. Non-text parts (images, audio, files) are
+    /// silently skipped because they use a separate token formula based on resolution/duration,
+    /// not BPE encoding. If your messages contain non-text content, the returned count will
+    /// be lower than the actual API token usage.
     ///
     /// # Arguments
     ///

--- a/tiktoken-rs/src/model.rs
+++ b/tiktoken-rs/src/model.rs
@@ -25,98 +25,98 @@ macro_rules! starts_with_any {
 /// use tiktoken_rs::model::get_context_size;
 /// let model = "gpt-4-32k";
 /// let context_size = get_context_size(model);
-/// assert_eq!(context_size, 32768);
+/// assert_eq!(context_size, Some(32768));
 /// ```
 ///
-/// # Note
+/// # Returns
 ///
-/// Returns a default of 4096 for unrecognized models. Use [`crate::tokenizer::get_tokenizer`]
-/// to check if a model is recognized before relying on this value.
-pub fn get_context_size(model: &str) -> usize {
+/// Returns `None` if the model is not recognized. Callers should handle this case
+/// explicitly rather than assuming a default context size.
+pub fn get_context_size(model: &str) -> Option<usize> {
     if let Some(rest) = model.strip_prefix("ft:") {
         let base = rest.split(':').next().unwrap_or(rest);
         return get_context_size(base);
     }
     if starts_with_any!(model, "gpt-5.4-mini", "gpt-5.4-nano") {
-        return 400_000;
+        return Some(400_000);
     }
     if starts_with_any!(model, "gpt-5.4") {
-        return 1_050_000;
+        return Some(1_050_000);
     }
     if starts_with_any!(model, "gpt-5.3-codex-spark") {
-        return 128_000;
+        return Some(128_000);
     }
     if starts_with_any!(model, "gpt-5") {
-        return 400_000;
+        return Some(400_000);
     }
     if starts_with_any!(model, "codex-mini") {
-        return 200_000;
+        return Some(200_000);
     }
     if starts_with_any!(model, "gpt-oss") {
-        return 131_072;
+        return Some(131_072);
     }
     if starts_with_any!(model, "o1-mini", "o1-preview") {
-        return 128_000;
+        return Some(128_000);
     }
     if starts_with_any!(model, "o1", "o3", "o4") {
-        return 200_000;
+        return Some(200_000);
     }
     if starts_with_any!(model, "gpt-4.1") {
-        return 1_047_576;
+        return Some(1_047_576);
     }
     if starts_with_any!(model, "chatgpt-4o", "gpt-4o") {
-        return 128_000;
+        return Some(128_000);
     }
     if starts_with_any!(model, "gpt-4.5") {
-        return 128_000;
+        return Some(128_000);
     }
     if starts_with_any!(model, "gpt-4-turbo-") {
-        return 128_000;
+        return Some(128_000);
     }
     if starts_with_any!(model, "gpt-4-0125") {
-        return 128_000;
+        return Some(128_000);
     }
     if starts_with_any!(model, "gpt-4-1106") {
-        return 128_000;
+        return Some(128_000);
     }
     if starts_with_any!(model, "gpt-4-32k") {
-        return 32_768;
+        return Some(32_768);
     }
     if starts_with_any!(model, "gpt-4") {
-        return 8192;
+        return Some(8192);
     }
     if starts_with_any!(model, "gpt-3.5-turbo-0125") {
-        return 16_385;
+        return Some(16_385);
     }
     if starts_with_any!(model, "gpt-3.5-turbo-1106") {
-        return 16_385;
+        return Some(16_385);
     }
     if starts_with_any!(model, "gpt-3.5-turbo-16k") {
-        return 16_385;
+        return Some(16_385);
     }
     if starts_with_any!(model, "gpt-3.5-turbo") {
-        return 16_385;
+        return Some(16_385);
     }
     if starts_with_any!(model, "text-davinci-002", "text-davinci-003") {
-        return 4097;
+        return Some(4097);
     }
     if starts_with_any!(model, "ada", "babbage", "curie") {
-        return 2049;
+        return Some(2049);
     }
     if starts_with_any!(model, "code-cushman-001") {
-        return 2048;
+        return Some(2048);
     }
     if starts_with_any!(model, "code-davinci-002") {
-        return 8001;
+        return Some(8001);
     }
     if starts_with_any!(model, "davinci") {
-        return 2049;
+        return Some(2049);
     }
     if starts_with_any!(model, "text-ada-001", "text-babbage-001", "text-curie-001") {
-        return 2049;
+        return Some(2049);
     }
     if starts_with_any!(model, "text-embedding-ada-002") {
-        return 8192;
+        return Some(8192);
     }
-    4096
+    None
 }

--- a/tiktoken-rs/src/model.rs
+++ b/tiktoken-rs/src/model.rs
@@ -94,7 +94,7 @@ pub fn get_context_size(model: &str) -> Option<usize> {
     if starts_with_any!(model, "gpt-3.5-turbo-16k") {
         return Some(16_385);
     }
-    if starts_with_any!(model, "gpt-3.5-turbo") {
+    if starts_with_any!(model, "gpt-3.5-turbo", "gpt-3.5", "gpt-35-turbo") {
         return Some(16_385);
     }
     if starts_with_any!(model, "text-davinci-002", "text-davinci-003") {

--- a/tiktoken-rs/tests/model.rs
+++ b/tiktoken-rs/tests/model.rs
@@ -59,6 +59,13 @@ fn test_gpt4_context_size() {
 }
 
 #[test]
+fn test_gpt35_aliases() {
+    // Common shorthand and Azure deployment name should resolve like gpt-3.5-turbo
+    assert_eq!(get_context_size("gpt-3.5"), Some(16_385));
+    assert_eq!(get_context_size("gpt-35-turbo"), Some(16_385));
+}
+
+#[test]
 fn test_unknown_model_returns_none() {
     assert_eq!(get_context_size("foo"), None);
     assert_eq!(get_context_size("not-a-model"), None);

--- a/tiktoken-rs/tests/model.rs
+++ b/tiktoken-rs/tests/model.rs
@@ -10,50 +10,57 @@ fn test_finetuned_context_size() {
         get_context_size("ft:gpt-4o:custom"),
         get_context_size("gpt-4o")
     );
-    assert_eq!(get_context_size("ft:gpt-5.4:org:name:id"), 1_050_000);
-    assert_eq!(get_context_size("ft:gpt-5.4-mini:org"), 400_000);
+    assert_eq!(get_context_size("ft:gpt-5.4:org:name:id"), Some(1_050_000));
+    assert_eq!(get_context_size("ft:gpt-5.4-mini:org"), Some(400_000));
 }
 
 #[test]
 fn test_o_series_context_size() {
-    assert_eq!(get_context_size("o1"), 200_000);
-    assert_eq!(get_context_size("o1-pro"), 200_000);
-    assert_eq!(get_context_size("o1-mini"), 128_000);
-    assert_eq!(get_context_size("o1-preview"), 128_000);
-    assert_eq!(get_context_size("o3"), 200_000);
-    assert_eq!(get_context_size("o3-mini"), 200_000);
-    assert_eq!(get_context_size("o3-pro"), 200_000);
-    assert_eq!(get_context_size("o4-mini"), 200_000);
+    assert_eq!(get_context_size("o1"), Some(200_000));
+    assert_eq!(get_context_size("o1-pro"), Some(200_000));
+    assert_eq!(get_context_size("o1-mini"), Some(128_000));
+    assert_eq!(get_context_size("o1-preview"), Some(128_000));
+    assert_eq!(get_context_size("o3"), Some(200_000));
+    assert_eq!(get_context_size("o3-mini"), Some(200_000));
+    assert_eq!(get_context_size("o3-pro"), Some(200_000));
+    assert_eq!(get_context_size("o4-mini"), Some(200_000));
 }
 
 #[test]
 fn test_gpt5_context_size() {
-    assert_eq!(get_context_size("gpt-5"), 400_000);
-    assert_eq!(get_context_size("gpt-5-mini"), 400_000);
-    assert_eq!(get_context_size("gpt-5-nano"), 400_000);
-    assert_eq!(get_context_size("gpt-5.4"), 1_050_000);
-    assert_eq!(get_context_size("gpt-5.4-pro"), 1_050_000);
-    assert_eq!(get_context_size("gpt-5.4-mini"), 400_000);
-    assert_eq!(get_context_size("gpt-5.4-nano"), 400_000);
+    assert_eq!(get_context_size("gpt-5"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5-mini"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5-nano"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5.4"), Some(1_050_000));
+    assert_eq!(get_context_size("gpt-5.4-pro"), Some(1_050_000));
+    assert_eq!(get_context_size("gpt-5.4-mini"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5.4-nano"), Some(400_000));
     // gpt-5.2 / 5.3 / codex variants
-    assert_eq!(get_context_size("gpt-5.2"), 400_000);
-    assert_eq!(get_context_size("gpt-5.2-pro"), 400_000);
-    assert_eq!(get_context_size("gpt-5.2-codex"), 400_000);
-    assert_eq!(get_context_size("gpt-5.3-codex"), 400_000);
-    assert_eq!(get_context_size("gpt-5.3-codex-spark"), 128_000);
-    assert_eq!(get_context_size("gpt-5.1-codex"), 400_000);
-    assert_eq!(get_context_size("gpt-5.1-codex-mini"), 400_000);
-    assert_eq!(get_context_size("gpt-5-codex"), 400_000);
-    assert_eq!(get_context_size("codex-mini-latest"), 200_000);
+    assert_eq!(get_context_size("gpt-5.2"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5.2-pro"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5.2-codex"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5.3-codex"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5.3-codex-spark"), Some(128_000));
+    assert_eq!(get_context_size("gpt-5.1-codex"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5.1-codex-mini"), Some(400_000));
+    assert_eq!(get_context_size("gpt-5-codex"), Some(400_000));
+    assert_eq!(get_context_size("codex-mini-latest"), Some(200_000));
 }
 
 #[test]
 fn test_gpt4_context_size() {
-    assert_eq!(get_context_size("gpt-4.5-preview"), 128_000);
-    assert_eq!(get_context_size("gpt-4.1"), 1_047_576);
-    assert_eq!(get_context_size("gpt-4.1-mini"), 1_047_576);
-    assert_eq!(get_context_size("gpt-4.1-nano"), 1_047_576);
-    assert_eq!(get_context_size("chatgpt-4o-latest"), 128_000);
-    assert_eq!(get_context_size("gpt-4o"), 128_000);
-    assert_eq!(get_context_size("gpt-4o-mini"), 128_000);
+    assert_eq!(get_context_size("gpt-4.5-preview"), Some(128_000));
+    assert_eq!(get_context_size("gpt-4.1"), Some(1_047_576));
+    assert_eq!(get_context_size("gpt-4.1-mini"), Some(1_047_576));
+    assert_eq!(get_context_size("gpt-4.1-nano"), Some(1_047_576));
+    assert_eq!(get_context_size("chatgpt-4o-latest"), Some(128_000));
+    assert_eq!(get_context_size("gpt-4o"), Some(128_000));
+    assert_eq!(get_context_size("gpt-4o-mini"), Some(128_000));
+}
+
+#[test]
+fn test_unknown_model_returns_none() {
+    assert_eq!(get_context_size("foo"), None);
+    assert_eq!(get_context_size("not-a-model"), None);
+    assert_eq!(get_context_size(""), None);
 }


### PR DESCRIPTION
### Why
Three API quality issues flagged during review:
1. `get_context_size` silently returned 4096 for unrecognized models, causing incorrect token budgets with no error
2. `num_tokens_from_messages` had a vague, grammatically incorrect error message that didn't tell the user which model or tokenizer was involved
3. `async_openai::num_tokens_from_messages` silently skips non-text content (images, audio, files) with no documentation

### Changes
- **Breaking:** `get_context_size` now returns `Option<usize>` — `None` for unrecognized models instead of a silent 4096 default
- `get_text_completion_max_tokens` and `get_chat_completion_max_tokens` now surface an explicit error for unknown models
- Added context sizes for `gpt-3.5` and `gpt-35-turbo` aliases that were accepted by the tokenizer but missing from context size lookup
- Error message in `num_tokens_from_messages` now includes the model name, detected tokenizer, and list of supported tokenizers
- Added doc comment to `async_openai::num_tokens_from_messages` warning that non-text content is not counted
- Version bump to 0.11.0 (breaking change)

### Test plan
- Run `cargo test --all-features` — all 56 tests pass
- Run `cargo test -- test_unknown_model_returns_none` — verifies `None` for `"foo"`, `"not-a-model"`, `""`
- Run `cargo test -- test_gpt35_aliases` — verifies `gpt-3.5` and `gpt-35-turbo` return `Some(16_385)`
- Verify `get_chat_completion_max_tokens("text-davinci-003", &messages)` returns a clear error mentioning P50kBase