### PR TITLE
Add 2-byte pair lookup table to skip hashmap for initial BPE merge scan

### DIFF
--- a/tiktoken-rs/src/patched_tiktoken.rs
+++ b/tiktoken-rs/src/patched_tiktoken.rs
@@ -94,6 +94,15 @@ impl CoreBPE {
         let mut sorted_token_bytes: Vec<Vec<u8>> = encoder.keys().cloned().collect();
         sorted_token_bytes.sort();
 
+        // Build the 2-byte pair lookup table (~256 KB, ~1 ms one-time cost).
+        let mut pair_table: Box<[Rank; PAIR_TABLE_SIZE]> = Box::new([Rank::MAX; PAIR_TABLE_SIZE]);
+        for (key, &rank) in &encoder {
+            if key.len() == 2 {
+                let idx = ((key[0] as u16) << 8 | key[1] as u16) as usize;
+                pair_table[idx] = rank;
+            }
+        }
+
         Ok(Self {
             encoder,
             special_tokens_encoder,
@@ -104,6 +113,7 @@ impl CoreBPE {
                 .map(|_| special_regex.clone())
                 .collect(),
             sorted_token_bytes,
+            pair_table,
         })
     }
 

--- a/tiktoken-rs/src/vendor_tiktoken.rs
+++ b/tiktoken-rs/src/vendor_tiktoken.rs
@@ -18,7 +18,14 @@ use rustc_hash::FxHashMap as HashMap;
 
 pub type Rank = u32;
 
-fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize, Rank)> {
+// Every distinct 2-byte sequence (256 byte values × 256). Indexed by (byte_a << 8) | byte_b.
+pub(crate) const PAIR_TABLE_SIZE: usize = 256 * 256;
+
+fn _byte_pair_merge(
+    ranks: &HashMap<Vec<u8>, Rank>,
+    piece: &[u8],
+    pair_table: Option<&[Rank; PAIR_TABLE_SIZE]>,
+) -> Vec<(usize, Rank)> {
     // This is a vector of (start, rank).
     // The rank is of the pair starting at position start.
     let mut parts = Vec::with_capacity(piece.len() + 1);
@@ -26,9 +33,16 @@ fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize,
     // Note that we hash bytes when indexing into `ranks`, not token pairs. As long as we train BPE
     // the way we currently do, this is equivalent. An easy way to break this would be to decouple
     // merge priority from token index or to prevent specific token merges.
+    //
+    // When `pair_table` is Some, the initial pair scan uses a flat `PAIR_TABLE_SIZE`-entry
+    // array indexed by the 2-byte pair instead of the hashmap. Subsequent merges (3+ byte
+    // sequences) always go through the hashmap, since 3+ byte keys don't fit in a u16.
     let mut min_rank: (Rank, usize) = (Rank::MAX, usize::MAX);
     for i in 0..piece.len() - 1 {
-        let rank = *ranks.get(&piece[i..i + 2]).unwrap_or(&Rank::MAX);
+        let rank = match pair_table {
+            Some(table) => table[((piece[i] as u16) << 8 | piece[i + 1] as u16) as usize],
+            None => *ranks.get(&piece[i..i + 2]).unwrap_or(&Rank::MAX),
+        };
         if rank < min_rank.0 {
             min_rank = (rank, i);
         }
@@ -76,11 +90,15 @@ fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize,
     parts
 }
 
-pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Rank> {
+pub fn byte_pair_encode(
+    piece: &[u8],
+    ranks: &HashMap<Vec<u8>, Rank>,
+    pair_table: Option<&[Rank; PAIR_TABLE_SIZE]>,
+) -> Vec<Rank> {
     if piece.len() == 1 {
         return vec![ranks[piece]];
     }
-    _byte_pair_merge(ranks, piece)
+    _byte_pair_merge(ranks, piece, pair_table)
         .windows(2)
         .map(|part| ranks[&piece[part[0].0..part[1].0]])
         .collect()
@@ -88,7 +106,7 @@ pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Ran
 
 pub fn byte_pair_split<'a>(piece: &'a [u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<&'a [u8]> {
     assert!(piece.len() > 1);
-    _byte_pair_merge(ranks, piece)
+    _byte_pair_merge(ranks, piece, None)
         .windows(2)
         .map(|part| &piece[part[0].0..part[1].0])
         .collect()
@@ -190,6 +208,10 @@ pub struct CoreBPE {
     pub(crate) special_regex_tls: Vec<Regex>,
     #[allow(dead_code)]
     pub(crate) sorted_token_bytes: Vec<Vec<u8>>,
+    /// Precomputed 2-byte pair to rank lookup table (~256 KB, built once at
+    /// construction). Used by encoding methods to skip the hashmap lookup for
+    /// the hot initial adjacent-pair scan inside `_byte_pair_merge`.
+    pub(crate) pair_table: Box<[Rank; PAIR_TABLE_SIZE]>,
 }
 
 impl CoreBPE {
@@ -231,7 +253,11 @@ impl CoreBPE {
             let piece = mat.unwrap().as_str().as_bytes();
             match self.encoder.get(piece) {
                 Some(token) => ret.push(*token),
-                None => ret.extend(&byte_pair_encode(piece, &self.encoder)),
+                None => ret.extend(&byte_pair_encode(
+                    piece,
+                    &self.encoder,
+                    Some(&self.pair_table),
+                )),
             }
         }
         ret
@@ -270,7 +296,7 @@ impl CoreBPE {
                     ret.push(*token);
                     continue;
                 }
-                let tokens = byte_pair_encode(piece, &self.encoder);
+                let tokens = byte_pair_encode(piece, &self.encoder, Some(&self.pair_table));
                 last_piece_token_len = tokens.len();
                 ret.extend(&tokens);
             }
@@ -402,7 +428,7 @@ impl CoreBPE {
                     // would be a regex split before the UTF-8 truncation point.
                     // Probably niche enough that no one will ever notice (after all, people didn't
                     // notice all the big holes in the previous unstable token implementation)
-                    Err(_) => byte_pair_encode(&possibility, &self.encoder),
+                    Err(_) => byte_pair_encode(&possibility, &self.encoder, Some(&self.pair_table)),
                     // Something like the following is intriguing but incorrect:
                     // Err(e) => self.encode_ordinary(unsafe {
                     //     std::str::from_utf8_unchecked(&possibility[..e.valid_up_to()])
@@ -438,10 +464,12 @@ impl CoreBPE {
                 let mut reencoded = byte_pair_encode(
                     &unstable_bytes[..unstable_bytes.len() - last_decoded.1],
                     &self.encoder,
+                    Some(&self.pair_table),
                 );
                 reencoded.extend(byte_pair_encode(
                     &unstable_bytes[unstable_bytes.len() - last_decoded.1..],
                     &self.encoder,
+                    Some(&self.pair_table),
                 ));
                 completions.insert(reencoded);
             }


### PR DESCRIPTION
## Summary

Adds a precomputed 2-byte pair to rank table (`Box<[Rank; 65536]>`, ~256 KB) on `CoreBPE`, used by `byte_pair_encode` to skip the hashmap lookup for the hot initial adjacent-pair scan. Subsequent merges (3+ byte spans) still go through the encoder hashmap; those keys don't fit in a u16 anyway.

Token output is byte-identical to vanilla. The optimization changes only how the initial pair scan is implemented inside `_byte_pair_merge`.

## Headline result

+2.8% size-weighted aggregate `encode_ordinary` throughput across 8 MiB of corpus, with positive gains on 7 of 8 tested corpora (range +0.6% to +11.9%). One slight regression: -3.8% on dense numeric content. Biggest wins on CJK Wikipedia (+11.9%) and FLORES multilingual (+8.6%), where the merger dominates encode time.

Apple M4 base (4P + 6E cores). Full per-corpus table in the appendix. Byte-equality validated against vanilla on a 230 MiB curated corpus (16 files, no divergences).

## Disclosures

- **+256 KB heap per `CoreBPE` instance**, built once at construction. Read-only after init, so Linux fork-based serving keeps it copy-on-write shared. For typical use (one tokenizer per process) the cost is invisible; multi-tokenizer-per-process systems should know.
- **Construction overhead is sub-millisecond.** Under 1 ms on the largest vocab (o200k_base, ~200k entries), within measurement noise on smaller ones. Full table in the appendix.

## Backward compatibility

- New `pair_table` field on `CoreBPE` is `pub(crate)`. External code constructs via `CoreBPE::new` as before; no API change visible to users.
- `byte_pair_encode` and `_byte_pair_merge` gain an optional `pair_table` parameter. These functions live in the private `vendor_tiktoken` module (not re-exported from `lib.rs`), so the signature change is internal only.
- No new public APIs, no behavior changes, no dependency additions.

## Testing

- Existing test suite: 56/56 tests pass (`cargo test --all-features`).
- Byte-equality validated against vanilla on the 230 MiB corpus.

---

## Appendix

### A. Methodology

Apple M4 base (4P + 6E cores). Criterion 100 samples per case, 3 s warmup, ~5 s measurement. N=2 per state for the per-optimization ablation (pair table alone vs vanilla, with `rustc-hash` kept at 1.1.0 in both states so the comparison isolates the table). Happy to rerun at higher N if useful.

Byte-equality validated by encoding the full 230 MiB curated corpus with both implementations and confirming token-for-token identical output across all 16 files. No divergences.

### B. Corpora used in this PR's measurements

8 corpora, ~1 MB each:

| Corpus | Source | What it tests |
|---|---|---|
| `wiki_en` | [wikimedia/wikipedia](https://huggingface.co/datasets/wikimedia/wikipedia) (en) | English Wikipedia, shuffled article excerpts |
| `wiki_zh` | [wikimedia/wikipedia](https://huggingface.co/datasets/wikimedia/wikipedia) (zh) | Chinese Wikipedia; CJK-heavy |
| `code_python` | [bigcode/the-stack-smol](https://huggingface.co/datasets/bigcode/the-stack-smol) (python) | Python source code |
| `flores200` | [Meta FLORES-200](https://github.com/facebookresearch/flores) | Concatenation of 200 languages' devtest splits |
| `stress_doc` | procedural | One long document, no paragraph breaks |
| `synthetic_numeric` | procedural | CSV / JSON logs / hex / dates / UUIDs |
| `merger_long_pieces` | procedural | Random 100 to 500 byte alphanumeric runs |
| `merger_repeated_pieces` | procedural | ~10 unique 20-50 byte pieces, repeated |

### C. Procedural corpora (detail + samples)

The four procedural corpora are generated locally. Each targets a specific algorithmic regime.

**`stress_doc`**: mixed-content document (random words, numbers, punctuation) with no paragraph breaks. Probes the long-input regime where fancy_regex can hit catastrophic-backtracking patterns.

```
sdmrulm ljwotlewvjc ) pnojbbyvh qzvrqbvlqsi ) wubpj bzrhxsjlmkuj . ; !
lpdcuvdauvu mysvwkscfyk ( 5492019 54359 evszryfefjz lba - - iflkgcfokjce
inodggcm 61 ? fsmqhrhm 98595 - 655044427 8691240 . yqvpa ...
```

**`synthetic_numeric`**: procedurally generated CSV rows, JSON logs, hex dumps, ISO timestamps, IPv4 addresses, and UUIDs. Tests numeric-heavy content where 2-byte digit pairs are rare in the encoder vocab (which is why this corpus shows a slight regression).

```
57.12.140.125
{"k0":67.66994874229113,"k1":91161,"k2":23.266089339073957}
649.8844,236696312,805.8193,298362082,379.9273,"item711"
0x1e14ae531acfdd67d25aba1a8374eb35c0dc61e9b37ea22b8b695f27cd22a969...
58478be9-3761-a56d-0aa0-bc138227d1cd
Mon Dec 11 2020 01:37:30 UTC
```

**`merger_long_pieces`**: random alphanumeric runs of 100 to 500 bytes per piece. Long pieces aren't single tokens in any standard vocab, so each piece exercises `byte_pair_encode`'s full merge loop heavily.

```
GRhxrnJgWQsNKVPwvrjFKqt6YrvfDliUWc7QSTR0YwDCXjD9T9M8Tra2JLIr6IzwgnS9
VPDi5TaO5deAlGQ18dD889UWuXeEys2Btiii5yvBqJiUFwcoEF1Q9Ci5wg74ja4z... (continues for hundreds of bytes)
```

**`merger_repeated_pieces`**: ~10 unique pieces of 20 to 50 bytes, sampled with repetition throughout the corpus. Exposes opportunities for LRU-caching of `byte_pair_encode` results.

```
uieahkwaxsqlfhgqyfazpgmefbcszuerrswx vjkjswbpvrgjxfyknsrpwqxqpbxffbqjqvyuvjbu
mxokvbjscokfktrpukpcrrquzszrhwrqdoioyjado nytzghujarzemafrxxwgcffslrhsfxqom
eyktdqsjntsjmhgcgtxwewy eyktdqsjntsjmhgcgtxwewy ...   (same piece, repeats)
```

### D. Per-corpus throughput (end-to-end `encode_ordinary`)

| Corpus | Vanilla (MiB/s) | With pair table (MiB/s) | Δ |
|---|---:|---:|---:|
| `wiki_zh` | 18.5 | 20.7 | +11.9% |
| `flores200` | 24.5 | 26.6 | +8.6% |
| `merger_repeated_pieces` | 47.6 | 49.8 | +4.6% |
| `code_python` | 30.0 | 30.7 | +2.3% |
| `wiki_en` | 33.6 | 34.0 | +1.2% |
| `stress_doc` | 17.1 | 17.2 | +0.6% |
| `merger_long_pieces` | 15.5 | 15.6 | +0.6% |
| `synthetic_numeric` | 18.6 | 17.9 | -3.8% |

### E. Construction-time overhead (per-encoding)

| Encoding | Vocab | Vanilla | + pair table | Δ |
|---|---:|---:|---:|---:|
| `o200k_base` | ~200k | 48.7 ms | 49.6 ms | +0.9 ms |
| `cl100k_base` | ~100k | 23.1 ms | 23.4 ms | +0.3 ms |
| `p50k_base` | ~50k | 11.4 ms | 11.3 ms | noise |
| `r50k_base` | ~50k | 11.2 ms | 11.5 ms | +0.3 ms |

Scales linearly with vocab size (one pass over the encoder entries).
