### PR TITLE
Bump rustc-hash from 1.1.0 to 2.1; MSRV bump to 1.77, ~3% encode speedup

### DIFF
--- a/tiktoken-rs/Cargo.toml
+++ b/tiktoken-rs/Cargo.toml
@@ -5,7 +5,7 @@ description = "Library for encoding and decoding with the tiktoken library in Ru
 include = ["assets/**/*", "src/**/*", "README.md"]
 edition = "2021"
 authors = ["Roger Zurawicki <roger@zura.wiki>"]
-rust-version = "1.73.0"
+rust-version = "1.77"
 keywords = ["openai", "ai", "gpt", "bpe"]
 homepage = "https://github.com/zurawiki/tiktoken-rs"
 repository = "https://github.com/zurawiki/tiktoken-rs"
@@ -25,7 +25,7 @@ dhat = { version = "0.3.2", optional = true }
 fancy-regex = "0.17.0"
 lazy_static = "1.5.0"
 regex = "1.12.3"
-rustc-hash = "1.1.0"
+rustc-hash = "2.1"
 
 [features]
 async-openai = ["dep:async-openai"]


### PR DESCRIPTION
## Summary

Bumps `rustc-hash` from `1.1.0` to `2.1`. This matches what upstream `openai/tiktoken` shipped (they bumped to `2` already) and brings a slightly faster hash function on modern x86_64 and aarch64.

## Measured perf impact

End-to-end `encode_ordinary` throughput on Apple M4 base, N=2 ablation (only this dep changed, all other optimizations kept off):

| Corpus | rustc-hash 1.1.0 (MiB/s) | rustc-hash 2.1 (MiB/s) | Δ |
|---|---:|---:|---:|
| `wiki_zh` | 18.5 | 20.8 | **+12.4%** |
| `flores200` | 24.5 | 26.6 | **+8.6%** |
| `stress_doc` | 17.1 | 18.3 | **+7.0%** |
| `merger_long_pieces` | 15.5 | 16.0 | +3.2% |
| `code_python` | 30.0 | 30.9 | +3.0% |
| `wiki_en` | 33.6 | 34.4 | +2.4% |
| `merger_repeated_pieces` | 47.6 | 47.0 | -1.3% |
| `synthetic_numeric` | 18.6 | 18.3 | -1.6% |

Median around +3%, with the largest wins on workloads that exercise the encoder hashmap most (CJK Wikipedia, multilingual FLORES). Two corpora regress slightly; consistent with the size of N=2 measurement noise.

## Required MSRV bump

`rustc-hash 2.x` requires Rust ≥ 1.77, so this PR also bumps `rust-version` from `1.73.0` to `1.77` (Rust 1.77 was released March 2024).

If the MSRV bump is unacceptable for your CI matrix or downstream users on locked toolchains, happy to close this PR; the change isn't load-bearing for any larger work.

## Testing

- `cargo test --all-features` passes (56/56 tests).
- `cargo +nightly fmt --all -- --check` is clean.
- HashMap iteration order changes between rustc-hash 1.x and 2.x. The test suite has no tests that depend on iteration order; verified by running it under both versions and getting identical results.

---

## Appendix

### A. Methodology

Apple M4 base (4P + 6E cores). Criterion 100 samples per case, 3 s warmup, ~5 s measurement, N=2 per state. The two states differ only in `rustc-hash` version (1.1.0 vs 2.1); all other code and dependencies are held constant so the comparison isolates the dep bump. Encode path benchmarked is `CoreBPE::encode_ordinary` through the regular fancy_regex pretokenizer (no other modifications).

### B. Corpora used

8 corpora, ~1 MB each:

| Corpus | Source | What it tests |
|---|---|---|
| `wiki_en` | [wikimedia/wikipedia](https://huggingface.co/datasets/wikimedia/wikipedia) (en) | English Wikipedia, shuffled article excerpts |
| `wiki_zh` | [wikimedia/wikipedia](https://huggingface.co/datasets/wikimedia/wikipedia) (zh) | Chinese Wikipedia; CJK-heavy |
| `code_python` | [bigcode/the-stack-smol](https://huggingface.co/datasets/bigcode/the-stack-smol) (python) | Python source code |
| `flores200` | [Meta FLORES-200](https://github.com/facebookresearch/flores) | Concatenation of 200 languages' devtest splits |
| `stress_doc` | procedural (locally generated) | One long document, no paragraph breaks |
| `synthetic_numeric` | procedural (locally generated) | CSV / JSON logs / hex / dates / UUIDs |
| `merger_long_pieces` | procedural (locally generated) | Random 100 to 500 byte alphanumeric runs |
| `merger_repeated_pieces` | procedural (locally generated) | ~10 unique 20-50 byte pieces, repeated |

### C. Procedural corpora (detail + samples)

**`stress_doc`**: mixed-content document (random words, numbers, punctuation) with no paragraph breaks. Probes the long-input regime where fancy_regex can hit catastrophic-backtracking patterns.

```
sdmrulm ljwotlewvjc ) pnojbbyvh qzvrqbvlqsi ) wubpj bzrhxsjlmkuj . ; !
lpdcuvdauvu mysvwkscfyk ( 5492019 54359 evszryfefjz lba - - iflkgcfokjce
inodggcm 61 ? fsmqhrhm 98595 - 655044427 8691240 . yqvpa ...
```

**`synthetic_numeric`**: procedurally generated CSV rows, JSON logs, hex dumps, ISO timestamps, IPv4 addresses, and UUIDs.

```
57.12.140.125
{"k0":67.66994874229113,"k1":91161,"k2":23.266089339073957}
649.8844,236696312,805.8193,298362082,379.9273,"item711"
0x1e14ae531acfdd67d25aba1a8374eb35c0dc61e9b37ea22b8b695f27cd22a969...
58478be9-3761-a56d-0aa0-bc138227d1cd
Mon Dec 11 2020 01:37:30 UTC
```

**`merger_long_pieces`**: random alphanumeric runs of 100 to 500 bytes per piece. Long pieces aren't single tokens in any standard vocab, so each piece exercises `byte_pair_encode`'s full merge loop heavily.

```
GRhxrnJgWQsNKVPwvrjFKqt6YrvfDliUWc7QSTR0YwDCXjD9T9M8Tra2JLIr6IzwgnS9
VPDi5TaO5deAlGQ18dD889UWuXeEys2Btiii5yvBqJiUFwcoEF1Q9Ci5wg74ja4z... (continues for hundreds of bytes)
```

**`merger_repeated_pieces`**: ~10 unique pieces of 20 to 50 bytes, sampled with repetition throughout the corpus.

```
uieahkwaxsqlfhgqyfazpgmefbcszuerrswx vjkjswbpvrgjxfyknsrpwqxqpbxffbqjqvyuvjbu
mxokvbjscokfktrpukpcrrquzszrhwrqdoioyjado nytzghujarzemafrxxwgcffslrhsfxqom
eyktdqsjntsjmhgcgtxwewy eyktdqsjntsjmhgcgtxwewy ...   (same piece, repeats)
```
