### PR TITLE
Backport tiktoken 0.13.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/tiktoken"]
 	path = vendor/tiktoken
 	url = https://github.com/openai/tiktoken.git
-	ref = refs/tags/0.9.0
+	ref = refs/tags/0.13.0

--- a/scripts/download_assets.sh
+++ b/scripts/download_assets.sh
@@ -1,24 +1,35 @@
 #!/usr/bin/env bash
 
-# Fail on first error, on undefined variables, and on failures in pipelines.
 set -euo pipefail
 
-export ASSETS=$(cat <<EOF
-https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe
-https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json
-https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken
-https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken
-https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken
-https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ASSET_DIR="${ASSET_DIR:-$REPO_ROOT/tiktoken-rs/assets}"
+
+ASSETS=$(cat <<EOF
+1ce1664773c50f3e0cc8842619a93edc4624525b728b188a9e0be33b7726adc5 https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe
+196139668be63f3b5d6574427317ae82f612a97c5d1cdaf36ed2256dbf636783 https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json
+306cd27f03c1a714eca7108e03d66b7dc042abe8c258b44c199a7ed9838dd930 https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken
+94b5ca7dff4d00767bc256fdd1b27e5b17361d7b8a5f968547f9f23eb70d2069 https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken
+223921b76ee99bde995b7ff738513eef100fb51d18c93597a113bcffe865b2a7 https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken
+446a9538cb6c348e3516120d7c08b09f57c36495e2acfffe59a5bf8b0cfb1a2d https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken
 EOF
 )
 
-# Download assets
 echo "Downloading assets..."
-for asset in $ASSETS; do
+mkdir -p "$ASSET_DIR"
+while read -r expected_hash asset; do
     echo "Downloading $asset..."
+    output="$ASSET_DIR/$(basename "$asset")"
     curl \
       --proto '=https' --tlsv1.2 -Sf -L \
-      -o ./assets/$(basename $asset)\
-      $asset
-done
+      -o "$output" \
+      "$asset"
+
+    actual_hash="$(shasum -a 256 "$output" | awk '{print $1}')"
+    if [[ "$actual_hash" != "$expected_hash" ]]; then
+        echo "Hash mismatch for $asset" >&2
+        echo "expected: $expected_hash" >&2
+        echo "actual:   $actual_hash" >&2
+        exit 1
+    fi
+done <<< "$ASSETS"

--- a/tiktoken-rs/Cargo.toml
+++ b/tiktoken-rs/Cargo.toml
@@ -3,9 +3,9 @@ name = "tiktoken-rs"
 version = "0.11.0"
 description = "Library for encoding and decoding with the tiktoken library in Rust"
 include = ["assets/**/*", "src/**/*", "README.md"]
-edition = "2021"
+edition = "2024"
 authors = ["Roger Zurawicki <roger@zura.wiki>"]
-rust-version = "1.73.0"
+rust-version = "1.85.0"
 keywords = ["openai", "ai", "gpt", "bpe"]
 homepage = "https://github.com/zurawiki/tiktoken-rs"
 repository = "https://github.com/zurawiki/tiktoken-rs"
@@ -25,7 +25,7 @@ dhat = { version = "0.3.2", optional = true }
 fancy-regex = "0.17.0"
 lazy_static = "1.5.0"
 regex = "1.12.3"
-rustc-hash = "1.1.0"
+rustc-hash = "2"
 
 [features]
 async-openai = ["dep:async-openai"]

--- a/tiktoken-rs/README.md
+++ b/tiktoken-rs/README.md
@@ -57,6 +57,24 @@ let tokens = bpe.encode_with_special_tokens(
 println!("Token count: {}", tokens.len());
 ```
 
+## Upgrading `encode` calls
+
+`CoreBPE::encode` mirrors upstream `tiktoken` and returns a `Result`.
+Propagate or unwrap the result before using the tokens:
+
+```rust
+use tiktoken_rs::o200k_base;
+
+let bpe = o200k_base().unwrap();
+let allowed = bpe.special_tokens();
+let (tokens, last_piece_token_len) = bpe.encode("hello <|endoftext|>", &allowed).unwrap();
+```
+
+The generic `encode_as` and `count` helpers also return `Result`.
+This release also follows upstream's Rust 2024 core, so projects need
+Rust 1.85 or newer. That floor comes from the vendored upstream code,
+not from a direct dependency MSRV.
+
 ## Counting max_tokens parameter for a chat completion request
 
 ```rust

--- a/tiktoken-rs/examples/count_chat_tokens.rs
+++ b/tiktoken-rs/examples/count_chat_tokens.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use tiktoken_rs::{get_chat_completion_max_tokens, ChatCompletionRequestMessage};
+use tiktoken_rs::{ChatCompletionRequestMessage, get_chat_completion_max_tokens};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let model = "gpt-4";

--- a/tiktoken-rs/examples/num_tokens_memory.rs
+++ b/tiktoken-rs/examples/num_tokens_memory.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use tiktoken_rs::{num_tokens_from_messages, ChatCompletionRequestMessage};
+use tiktoken_rs::{ChatCompletionRequestMessage, num_tokens_from_messages};
 
 static SIZE_FACTOR: usize = 128;
 static CONTENT: &str = include_str!("./example_text.txt");

--- a/tiktoken-rs/src/api.rs
+++ b/tiktoken-rs/src/api.rs
@@ -1,12 +1,11 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::{
-    cl100k_base_singleton,
+    CoreBPE, cl100k_base_singleton,
     model::get_context_size,
     o200k_base_singleton, o200k_harmony_singleton, p50k_base_singleton, p50k_edit_singleton,
     r50k_base_singleton,
-    tokenizer::{get_tokenizer, Tokenizer},
-    CoreBPE,
+    tokenizer::{Tokenizer, get_tokenizer},
 };
 
 /// Returns the maximum number of tokens available for a text completion, given a model and prompt.

--- a/tiktoken-rs/src/lib.rs
+++ b/tiktoken-rs/src/lib.rs
@@ -12,7 +12,8 @@ pub use singleton::*;
 pub use tiktoken_ext::openai_public::*;
 
 pub use patched_tiktoken::FromRank;
-pub use vendor_tiktoken::byte_pair_split;
 pub use vendor_tiktoken::CoreBPE;
 pub use vendor_tiktoken::DecodeKeyError;
+pub use vendor_tiktoken::EncodeError;
 pub use vendor_tiktoken::Rank;
+pub use vendor_tiktoken::byte_pair_split;

--- a/tiktoken-rs/src/patched_tiktoken.rs
+++ b/tiktoken-rs/src/patched_tiktoken.rs
@@ -1,6 +1,6 @@
 use super::vendor_tiktoken::*;
-use anyhow::anyhow;
 use anyhow::Result;
+use anyhow::anyhow;
 use fancy_regex::Regex;
 use rustc_hash::FxHashMap as HashMap;
 use std::collections::HashSet;
@@ -152,16 +152,19 @@ impl CoreBPE {
 
     /// Like [`encode`](CoreBPE::encode), but converts each token from
     /// [`Rank`] (`u32`) into `T`.
+    ///
+    /// Returns the same error as [`encode`](CoreBPE::encode) if tokenization
+    /// fails.
     pub fn encode_as<T: FromRank>(
         &self,
         text: &str,
         allowed_special: &HashSet<&str>,
-    ) -> (Vec<T>, usize) {
-        let (tokens, last_piece_token_len) = self.encode(text, allowed_special);
-        (
+    ) -> Result<(Vec<T>, usize)> {
+        let (tokens, last_piece_token_len) = self.encode(text, allowed_special)?;
+        Ok((
             tokens.into_iter().map(T::from_rank).collect(),
             last_piece_token_len,
-        )
+        ))
     }
 
     // ====================
@@ -179,9 +182,9 @@ impl CoreBPE {
     /// Returns the number of tokens that `encode` would produce for the given
     /// `allowed_special` set, without returning the token list itself.
     ///
-    /// Equivalent to `self.encode(text, allowed_special).0.len()`.
-    pub fn count(&self, text: &str, allowed_special: &HashSet<&str>) -> usize {
-        self.encode(text, allowed_special).0.len()
+    /// Equivalent to `self.encode(text, allowed_special)?.0.len()`.
+    pub fn count(&self, text: &str, allowed_special: &HashSet<&str>) -> Result<usize> {
+        Ok(self.encode(text, allowed_special)?.0.len())
     }
 
     /// Returns the number of tokens that `encode_with_special_tokens` would

--- a/tiktoken-rs/src/tiktoken_ext/openai_public.rs
+++ b/tiktoken-rs/src/tiktoken_ext/openai_public.rs
@@ -6,7 +6,7 @@ pub const ENDOFPROMPT: &str = "<|endofprompt|>";
 
 /// Adaptation of the tiktoken crate for use in Rust projects
 use anyhow::Result;
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 
 use rustc_hash::FxHashMap as HashMap;
 

--- a/tiktoken-rs/src/tokenizer.rs
+++ b/tiktoken-rs/src/tokenizer.rs
@@ -30,15 +30,13 @@ pub enum Tokenizer {
 }
 
 // Keep this in sync with:
-// https://github.com/openai/tiktoken/blob/eedc856364506a9d4651645a0290eb0ba81e6935/tiktoken/model.py#L7-L27
+// https://github.com/openai/tiktoken/blob/0.13.0/tiktoken/model.py#L7-L28
 const MODEL_PREFIX_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
     ("o1-", Tokenizer::O200kBase),
     ("o3-", Tokenizer::O200kBase),
-    ("o4-", Tokenizer::O200kBase),
+    ("o4-mini-", Tokenizer::O200kBase),
     // chat
-    ("gpt-5.", Tokenizer::O200kBase), // e.g., gpt-5.4-mini, gpt-5.3-codex, gpt-5.2-pro
     ("gpt-5-", Tokenizer::O200kBase),
-    ("codex-mini", Tokenizer::O200kBase), // codex-mini-latest
     ("gpt-4.5-", Tokenizer::O200kBase),
     ("gpt-4.1-", Tokenizer::O200kBase),
     ("chatgpt-4o-", Tokenizer::O200kBase),
@@ -49,17 +47,21 @@ const MODEL_PREFIX_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
     ("gpt-oss-", Tokenizer::O200kHarmony),
 ];
 
+const EXTRA_MODEL_PREFIX_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
+    ("gpt-5.", Tokenizer::O200kBase),
+    ("codex-mini", Tokenizer::O200kBase),
+];
+
 // Keep this in sync with:
-// https://github.com/openai/tiktoken/blob/eedc856364506a9d4651645a0290eb0ba81e6935/tiktoken/model.py#L29-L84
+// https://github.com/openai/tiktoken/blob/0.13.0/tiktoken/model.py#L30-L86
 const MODEL_TO_TOKENIZER: &[(&str, Tokenizer)] = &[
     // reasoning
     ("o1", Tokenizer::O200kBase),
     ("o3", Tokenizer::O200kBase),
-    ("o4", Tokenizer::O200kBase),
+    ("o4-mini", Tokenizer::O200kBase),
     // chat
     ("gpt-5", Tokenizer::O200kBase),
     ("gpt-4.1", Tokenizer::O200kBase),
-    ("chatgpt-4o-latest", Tokenizer::O200kBase),
     ("gpt-4o", Tokenizer::O200kBase),
     ("gpt-4", Tokenizer::Cl100kBase),
     ("gpt-3.5-turbo", Tokenizer::Cl100kBase),
@@ -157,6 +159,12 @@ pub fn get_tokenizer(model_name: &str) -> Option<Tokenizer> {
     {
         return Some(tokenizer.1);
     }
+    if let Some(tokenizer) = EXTRA_MODEL_PREFIX_TO_TOKENIZER
+        .iter()
+        .find(|(model_prefix, _)| model_name.starts_with(*model_prefix))
+    {
+        return Some(tokenizer.1);
+    }
 
     None
 }
@@ -193,8 +201,15 @@ mod tests {
             get_tokenizer("codex-mini-latest"),
             Some(Tokenizer::O200kBase)
         );
-        // Edge case: gpt-5.0 matches the gpt-5. prefix
         assert_eq!(get_tokenizer("gpt-5.0"), Some(Tokenizer::O200kBase));
+        // Reasoning series
+        assert_eq!(get_tokenizer("o4-mini"), Some(Tokenizer::O200kBase));
+        assert_eq!(
+            get_tokenizer("o4-mini-2026-06-02"),
+            Some(Tokenizer::O200kBase)
+        );
+        assert_eq!(get_tokenizer("o4"), None);
+        assert_eq!(get_tokenizer("o4-pro"), None);
         // GPT-4 series
         assert_eq!(get_tokenizer("gpt-4o"), Some(Tokenizer::O200kBase));
         assert_eq!(

--- a/tiktoken-rs/src/vendor_tiktoken.rs
+++ b/tiktoken-rs/src/vendor_tiktoken.rs
@@ -18,6 +18,131 @@ use rustc_hash::FxHashMap as HashMap;
 
 pub type Rank = u32;
 
+use std::collections::BinaryHeap;
+
+#[derive(Eq, PartialEq, Clone, Copy)]
+struct Merge {
+    start: usize,
+    rank: Rank,
+}
+
+impl Ord for Merge {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other
+            .rank
+            .cmp(&self.rank)
+            .then_with(|| other.start.cmp(&self.start))
+    }
+}
+
+impl PartialOrd for Merge {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+struct State {
+    prev: usize,
+    end: usize,
+    next_end: usize,
+    next_rank: Rank,
+    cur_rank: Rank,
+}
+
+fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<Rank> {
+    let mut state = Vec::with_capacity(piece.len());
+    state.push(State {
+        prev: usize::MAX,
+        end: 1,
+        next_end: 2,
+        next_rank: Rank::MAX,
+        cur_rank: Rank::MAX,
+    });
+
+    let mut heap = BinaryHeap::with_capacity(piece.len());
+    for i in 0..piece.len() - 1 {
+        if let Some(&rank) = ranks.get(&piece[i..i + 2]) {
+            heap.push(Merge { start: i, rank });
+            state[i].next_rank = rank;
+        }
+        // note this is happening offset by 1
+        state.push(State {
+            prev: i,
+            end: i + 2,
+            next_end: i + 3,
+            next_rank: Rank::MAX,
+            cur_rank: Rank::MAX,
+        });
+    }
+
+    // Repeatedly find the valid merge with smallest rank. We merge the (left) token that
+    // starts at `start` and ends at `state[start].end` with the (right) token that starts at
+    // `state[start].end` and ends at `state[start].next_end`.  We invalidate the old merges
+    // (the ones that started at `state[start].end` and ended at `state[start]`) and add the two
+    // new potential merges to the heap.
+
+    let potential_merge = {
+        #[inline(always)]
+        |state: &mut Vec<State>,
+         heap: &mut BinaryHeap<Merge>,
+         start: usize,
+         next_end_item: usize| {
+            state[start].next_end = next_end_item;
+            state[start].next_rank = Rank::MAX; // Always invalidate the old merge
+            if next_end_item <= piece.len()
+                && let Some(&rank) = ranks.get(&piece[start..next_end_item])
+            {
+                // We have a valid potential merge!
+                heap.push(Merge { start, rank });
+                state[start].next_rank = rank;
+            }
+        }
+    };
+
+    while let Some(left) = heap.pop() {
+        if left.rank == Rank::MAX {
+            break;
+        }
+        if left.rank != state[left.start].next_rank {
+            continue; // This merge was invalidated, ignore it
+        }
+
+        let left_start = left.start;
+        let right_start = state[left_start].end;
+        let right_end = state[left_start].next_end;
+        debug_assert!(right_end == state[right_start].end);
+        let right_next_end = state[right_start].next_end;
+
+        // Merge left and right into a single token
+        state[left_start].cur_rank = state[left_start].next_rank;
+        state[left_start].end = right_end;
+        potential_merge(&mut state, &mut heap, left_start, right_next_end);
+        if right_end < state.len() {
+            state[right_end].prev = left_start;
+        }
+        // Update the merge that ends at left_start
+        if left_start > 0 {
+            let prev_start = state[left_start].prev;
+            potential_merge(&mut state, &mut heap, prev_start, right_end);
+        }
+        // Invalidate the merge starting at right_start, so we ignore it when it comes off the heap
+        state[right_start].next_rank = Rank::MAX;
+    }
+
+    let mut result = Vec::new();
+    let mut i = 0;
+    while i < state.len() {
+        if state[i].cur_rank != Rank::MAX {
+            result.push(state[i].cur_rank);
+        } else {
+            result.push(ranks[&piece[i..state[i].end]]);
+        }
+        i = state[i].end;
+    }
+    result
+}
+
 fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize, Rank)> {
     // This is a vector of (start, rank).
     // The rank is of the pair starting at position start.
@@ -77,13 +202,18 @@ fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize,
 }
 
 pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Rank> {
-    if piece.len() == 1 {
+    let piece_len = piece.len();
+
+    if piece_len == 1 {
         return vec![ranks[piece]];
     }
-    _byte_pair_merge(ranks, piece)
-        .windows(2)
-        .map(|part| ranks[&piece[part[0].0..part[1].0]])
-        .collect()
+    if piece_len < 100 {
+        return _byte_pair_merge(ranks, piece)
+            .windows(2)
+            .map(|part| ranks[&piece[part[0].0..part[1].0]])
+            .collect();
+    }
+    _byte_pair_merge_large(ranks, piece)
 }
 
 pub fn byte_pair_split<'a>(piece: &'a [u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<&'a [u8]> {
@@ -177,6 +307,19 @@ impl std::fmt::Display for DecodeError {
 
 impl std::error::Error for DecodeError {}
 
+#[derive(Debug, Clone)]
+pub struct EncodeError {
+    pub message: String,
+}
+
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Could not encode string: {}", self.message)
+    }
+}
+
+impl std::error::Error for EncodeError {}
+
 pub const MAX_NUM_THREADS: usize = 128;
 
 // #[cfg_attr(feature = "python", pyclass)]
@@ -237,7 +380,11 @@ impl CoreBPE {
         ret
     }
 
-    pub fn encode(&self, text: &str, allowed_special: &HashSet<&str>) -> (Vec<Rank>, usize) {
+    pub fn encode(
+        &self,
+        text: &str,
+        allowed_special: &HashSet<&str>,
+    ) -> Result<(Vec<Rank>, usize), EncodeError> {
         let special_regex = self._get_tl_special_regex();
         let regex = self._get_tl_regex();
         let mut ret = vec![];
@@ -263,8 +410,17 @@ impl CoreBPE {
             let end = next_special.map_or(text.len(), |m| m.start());
 
             // Okay, here we go, compare this logic to encode_ordinary
-            for mat in regex.find_iter(&text[start..end]) {
-                let piece = mat.unwrap().as_str().as_bytes();
+            for mat_res in regex.find_iter(&text[start..end]) {
+                let mat = match mat_res {
+                    Ok(m) => m,
+                    Err(e) => {
+                        return Err(EncodeError {
+                            message: format!("Regex error while tokenizing: {e}"),
+                        });
+                    }
+                };
+
+                let piece = mat.as_str().as_bytes();
                 if let Some(token) = self.encoder.get(piece) {
                     last_piece_token_len = 1;
                     ret.push(*token);
@@ -290,7 +446,7 @@ impl CoreBPE {
 
         // last_piece_token_len is how many tokens came from the last regex split. This is used
         // for determining unstable tokens, since you can't merge across (stable) regex splits
-        (ret, last_piece_token_len)
+        Ok((ret, last_piece_token_len))
     }
 
     fn _increase_last_piece_token_len(
@@ -309,12 +465,7 @@ impl CoreBPE {
             let token_is_all_space = |token| {
                 self.decoder
                     .get(token)
-                    .map(|token_bytes| {
-                        token_bytes
-                            .iter()
-                            .rev()
-                            .all(|&b| [b' ', b'\n', b'\t'].contains(&b))
-                    })
+                    .map(|token_bytes| token_bytes.iter().rev().all(|&b| b" \n\t".contains(&b)))
                     .unwrap_or(false)
             };
             if last_piece_token_len > 0
@@ -337,7 +488,7 @@ impl CoreBPE {
         text: &str,
         allowed_special: &HashSet<&str>,
     ) -> (Vec<Rank>, HashSet<Vec<Rank>>) {
-        let (tokens, last_piece_token_len) = self.encode(text, allowed_special);
+        let (tokens, last_piece_token_len) = self.encode(text, allowed_special).unwrap();
         if last_piece_token_len == 0 {
             // If last_piece_token_len is zero, the last token was a special token and we have
             // no unstable bytes
@@ -521,7 +672,7 @@ impl CoreBPE {
 
     pub fn encode_with_special_tokens(&self, text: &str) -> Vec<Rank> {
         let allowed_special = self.special_tokens();
-        self.encode(text, &allowed_special).0
+        self.encode(text, &allowed_special).unwrap().0
     }
 }
 
@@ -530,7 +681,7 @@ mod tests {
     // use fancy_regex::Regex;
     use rustc_hash::FxHashMap as HashMap;
 
-    use crate::{byte_pair_split, Rank};
+    use crate::{Rank, byte_pair_split};
 
     fn setup_ranks() -> HashMap<Vec<u8>, Rank> {
         HashMap::from_iter([(b"ab".to_vec(), 0), (b"cd".to_vec(), 1)])

--- a/tiktoken-rs/tests/tiktoken.rs
+++ b/tiktoken-rs/tests/tiktoken.rs
@@ -1,8 +1,8 @@
 use rustc_hash::FxHashMap as HashMap;
 
 use tiktoken_rs::{
-    byte_pair_split, cl100k_base, o200k_base, o200k_harmony, p50k_base, p50k_base_singleton,
-    p50k_edit, r50k_base, CoreBPE, Rank,
+    CoreBPE, Rank, byte_pair_split, cl100k_base, o200k_base, o200k_harmony, p50k_base,
+    p50k_base_singleton, p50k_edit, r50k_base,
 };
 
 #[test]
@@ -92,7 +92,9 @@ fn cl100k_split_test() {
     let tokenized = tokenized.unwrap();
     assert_eq!(
         tokenized,
-        vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]
+        vec![
+            "This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"
+        ]
     );
 }
 
@@ -123,7 +125,9 @@ fn o200k_split_test() {
     let tokenized = tokenized.unwrap();
     assert_eq!(
         tokenized,
-        vec!["This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"]
+        vec![
+            "This", " is", " a", " test", "        ", " with", " a", " lot", " of", " spaces"
+        ]
     );
 }
 
@@ -294,8 +298,8 @@ fn test_encode_as_generic() {
 
     // encode_as: test tuple return
     let allowed = bpe.special_tokens();
-    let (enc, last_len) = bpe.encode(text, &allowed);
-    let (enc_usize, last_len_as): (Vec<usize>, usize) = bpe.encode_as(text, &allowed);
+    let (enc, last_len) = bpe.encode(text, &allowed).unwrap();
+    let (enc_usize, last_len_as): (Vec<usize>, usize) = bpe.encode_as(text, &allowed).unwrap();
     assert_eq!(
         enc.iter().map(|&t| t as usize).collect::<Vec<_>>(),
         enc_usize
@@ -308,6 +312,12 @@ fn assert_count_matches_encode(bpe: &CoreBPE, text: &str) {
     assert_eq!(
         bpe.count_with_special_tokens(text),
         bpe.encode_with_special_tokens(text).len()
+    );
+
+    let allowed = bpe.special_tokens();
+    assert_eq!(
+        bpe.count(text, &allowed).unwrap(),
+        bpe.encode(text, &allowed).unwrap().0.len()
     );
 }
 
@@ -331,5 +341,25 @@ fn count_matches_encode() {
         for text in &texts {
             assert_count_matches_encode(bpe, text);
         }
+    }
+}
+
+#[test]
+fn test_large_repeated_o200k_base() {
+    let bpe = o200k_base().unwrap();
+    let text = "x".repeat(1_000_000);
+    let tokens = bpe.encode_with_special_tokens(&text);
+    assert!(!tokens.is_empty());
+    assert_eq!(bpe.decode(&tokens).unwrap(), text);
+}
+
+#[test]
+fn test_large_merge_threshold_roundtrips() {
+    let bpe = o200k_base().unwrap();
+    for len in [99, 100, 101] {
+        let text = "x".repeat(len);
+        let tokens = bpe.encode_with_special_tokens(&text);
+        assert!(!tokens.is_empty(), "empty tokens for length {len}");
+        assert_eq!(bpe.decode(&tokens).unwrap(), text);
     }
 }


### PR DESCRIPTION
### Why
Backports OpenAI tiktoken 0.13.0 so the vendored Rust core stays close to the upstream implementation and carries the latest large-input BPE fixes.

### Changes
- Update the vendored OpenAI submodule from 0.9.0 to 0.13.0
- Backport upstream Rust core changes, including large-piece BPE merging and `CoreBPE::encode` returning `Result`
- Update Rust wrappers, tests, and README upgrade notes for the new `encode`/`count` result handling
- Mirror upstream Rust 2024 settings and `rustc-hash = 2`; Rust 1.85 is required by upstream alignment, not dependency MSRV
- Keep upstream model maps literal and isolate local extra prefixes separately
- Add checksum verification to asset downloads and ShellCheck-compatible script changes

### Breaking changes reviewed
- `CoreBPE::encode` now returns `Result<(Vec<Rank>, usize), EncodeError>`: migrated local callers and documented the upgrade path
- `encode_as` and `count` now return `Result` because they call `encode`
- Rust 1.85+ is required to stay aligned with upstream Rust 2024 code

### References
- OpenAI tiktoken 0.13.0: https://github.com/openai/tiktoken/releases/tag/0.13.0
- Upstream commit: https://github.com/openai/tiktoken/commit/fa8b65d062fb6a656ac3810c89efde4c8ab999e2

### Test plan
- `just lint`
- `just build`
- `just test`
- `shellcheck scripts/*.sh`